### PR TITLE
add MIT License file to the project

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Shubhrali jain 
+Copyright (c) 2025 Shubrali Jain 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Added the MIT License to the project to define usage rights and permissions for contributors and users. This license allows reuse, modification, and distribution with proper attribution while limiting liability and warranty

Issue (#19 )