### PR TITLE
[Bug]:SignUp route fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "chart.js": "^4.5.0",
         "cors": "^2.8.5",
         "framer-motion": "^12.23.12",
+        "lucide-react": "^0.536.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.5.0",
@@ -14364,6 +14365,14 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.536.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.536.0.tgz",
+      "integrity": "sha512-2PgvNa9v+qz4Jt/ni8vPLt4jwoFybXHuubQT8fv4iCW5TjDxkbZjNZZHa485ad73NSEn/jdsEtU57eE1g+ma8A==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "chart.js": "^4.5.0",
     "cors": "^2.8.5",
     "framer-motion": "^12.23.12",
+    "lucide-react": "^0.536.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.5.0",

--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import TripRecommender from "./pages/TripRecommender";
 
 import "./index.css";
 import Footer from "./Components/Footer";
+import Signup from "./pages/Signup";
 
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -26,7 +27,9 @@ function App() {
       {/* 🧱 Add padding to prevent content being hidden behind navbar */}
       <div className="pt-20"> {/* Adjust based on navbar height */}
         <Routes>
-          <Route path="/" element={<HomeSplit setIsLoggedIn={setIsLoggedIn} />} />
+          {/* <Route path="/" element={<HomeSplit setIsLoggedIn={setIsLoggedIn} />} /> */}
+           {/* <Route path="/" element={<><HomeSplit setIsLoggedIn={setIsLoggedIn}/><Signup setIsLoggedIn={setIsLoggedIn} /> </>} /> */}
+           <Route path="/" element={<>< Signup setIsLoggedIn={setIsLoggedIn} /> </>} />
           <Route path="/login" element={<Login setIsLoggedIn={setIsLoggedIn} />} />
           <Route path="/plan" element={isLoggedIn ? <PlanTrip /> : <Navigate to="/login" />} />
           <Route path="/expenses" element={isLoggedIn ? <ExpenseTracker /> : <Navigate to="/login" />} />

--- a/src/Components/Hero.jsx
+++ b/src/Components/Hero.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function HeroSection({ navigateTo }) {
+  const navigate = useNavigate();
+
+  const handleStartPlanningClick = () => {
+    navigate(navigateTo || "/login");  // Navigate to the given path or default to home
+  };
+
+  return (
+   <><div className="hero-box">
+            <h1>Plan Your Next Adventure</h1>
+            <p>Discover amazing places and create unforgettable memories.</p>
+            <button onClick={handleStartPlanningClick}>Start Planning →</button>
+          </div></>
+  );
+}

--- a/src/pages/HomeSplit.jsx
+++ b/src/pages/HomeSplit.jsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from "react-router-dom";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import "./HomeSplit.css";
+import HeroSection from "../Components/Hero";
 
 export default function HomeSplit({ setIsLoggedIn }) {
   const nameInputRef = useRef(null);
@@ -29,15 +30,10 @@ export default function HomeSplit({ setIsLoggedIn }) {
 
   return (
     <div className="page-background">
-      <div className="overlay">
-        <div className="split-content">
+      <div className="overlay ">
+        <div className="flex flex-col  justify-center lg:flex-row  items-center split-content">
           {/* Hero Section */}
-          <div className="hero-box">
-            <h1>Plan Your Next Adventure</h1>
-            <p>Discover amazing places and create unforgettable memories.</p>
-            <button onClick={handleStartPlanningClick}>Start Planning →</button>
-          </div>
-
+          <HeroSection/>
           {/* Signup Section */}
           <div className="signup-box">
             <form className="signup-form" onSubmit={handleSignup}>

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,27 +1,37 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Link } from "react-router-dom";
 import { ToastContainer, toast } from "react-toastify";
+import { Loader2 } from "lucide-react";  // Import the loading spinner icon
 import "react-toastify/dist/ReactToastify.css";
-import "./HomeSplit.css";
+import HeroSection from "../Components/Hero";
 
-export default function Signup() {
-  const [form, setForm] = useState({
-    name: "",
-    email: "",
-    password: "",
-  });
+
+export default function Signup({ setIsLoggedIn }) {
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
+  const [isLoggedInLocal, setIsLoggedInLocal] = useState(false);
+  const [isLoading, setIsLoading] = useState(false); // Track loading state
 
-  const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
-  };
-
-  const handleSubmit = (e) => {
+  const handleSignup = (e) => {
     e.preventDefault();
 
-    if (form.name && form.email && form.password) {
+    // Basic validation
+    if (name && email && password) {
+      setIsLoading(true); // Set loading state to true when signup is initiated
+
       toast.success("Signup successful!");
-      console.log("Signup Data:", form);
+      
+      setTimeout(() => {
+        setIsLoggedIn(true);  // Set login state to true
+        setIsLoggedInLocal(true);  // Track login state in component state
+        setIsLoading(false);  // Reset loading state
+        navigate("/plan");  // Redirect after showing the toast
+      }, 1500); // Wait for 1.5 seconds before redirecting
+
     } else {
       toast.error("Please fill all fields");
     }
@@ -32,68 +42,77 @@ export default function Signup() {
       <div className="overlay">
         <div className="split-content">
           {/* Hero Section */}
-          <div className="hero-box">
-            <h1>Start Your Journey</h1>
-            <p>Sign up and get ready to explore the world with us!</p>
-            <button>Explore Now →</button>
-          </div>
-
+         <HeroSection/>
           {/* Signup Section */}
           <div className="signup-box">
-            <form className="signup-form" onSubmit={handleSubmit}>
-              <h2>Sign Up</h2>
+            <form className="signup-form space-y-4" onSubmit={handleSignup}>
+              <h2 className="text-3xl font-bold">Sign Up</h2>
 
               <input
                 type="text"
                 placeholder="Name"
-                name="name"
-                value={form.name}
-                onChange={handleChange}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="w-full p-3 rounded-md border border-gray-300"
                 required
               />
 
               <input
                 type="email"
                 placeholder="Email"
-                name="email"
-                value={form.email}
-                onChange={handleChange}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full p-3 rounded-md border border-gray-300"
                 required
               />
 
               <input
                 type={showPassword ? "text" : "password"}
                 placeholder="Password"
-                name="password"
-                value={form.password}
-                onChange={handleChange}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full p-3 rounded-md border border-gray-300"
                 required
               />
 
-              <label style={{ margin: "8px 0", fontSize: "14px" }}>
+              <label className="flex items-center space-x-2 text-sm">
                 <input
                   type="checkbox"
                   checked={showPassword}
                   onChange={() => setShowPassword(!showPassword)}
-                  style={{ marginRight: "8px" }}
+                  className="form-checkbox h-4 w-4"
                 />
-                Show Password
+                <span>Show Password</span>
               </label>
 
-              <button type="submit">Create Account</button>
+              <button 
+                type="submit" 
+                className="w-full p-3 mt-4 bg-blue-500 text-white rounded-md focus:outline-none disabled:bg-gray-300"
+                disabled={isLoading}
+              >
+                {isLoading ? (
+                  <Loader2 size={18} className="animate-spin mx-auto" />
+                ) : (
+                  "Create Account"
+                )}
+              </button>
 
-              <p style={{ textAlign: "center" }}>
+              <p className="text-center mt-4">
                 Already have an Account?{" "}
-                <Link to="/login" style={{ color: "blue" }}>
+                <Link to="/login" className="text-blue-500 hover:underline">
                   Login
                 </Link>
               </p>
             </form>
+
+            {isLoggedInLocal && (
+              <p className="success-message text-center text-green-600">Logged in successfully</p>
+            )}
           </div>
         </div>
       </div>
 
-      {/* Toast Container */}
+      {/* Toast Notification Container */}
       <ToastContainer
         position="bottom-left"
         autoClose={3000}

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import "./HomeSplit.css";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import HeroSection from "../Components/Hero";
 
 export default function Login({ setIsLoggedIn }) {
   const navigate = useNavigate();
@@ -30,11 +31,7 @@ export default function Login({ setIsLoggedIn }) {
       <div className="overlay">
         <div className="split-content">
           {/* Hero Section */}
-          <div className="hero-box">
-            <h1>Plan Your Next Adventure</h1>
-            <p>Discover amazing places and create unforgettable memories.</p>
-            <button>Start Planning →</button>
-          </div>
+          <HeroSection/>
 
           {/* Login Section */}
           <div className="signup-box">


### PR DESCRIPTION
**PR Title**: Fixing the SignUp and its redirect route
*Description* 
This PR introduces->
1. The SignUp button is working successfully redirecting the user to the '/plan' route.
2. A loader has been added to the Sign up button from lucide-react so that while the react-toast message of successful signup loads, it spins across the signUp button.
3. The signup button upon getting clicked , now sets the isLoggedIn state variable to true and now uses the root route "/" to be rendered from the App.js
4. A Hero component has been introduced under the components directory and a HeroSection created that will be rendered to the SignUp and login components instead of the hardcoded hero section in SignUp and login components, hence enhancing its reusability and better maintenance.
5. The HomeSplit Component previously was rendered under the root "/" route that carried the SignUp segment and navigation as well as IsLoggedIn state variable as prop hardcoded in it. This component is no longer rendered in App.js to avoid duplicacy of the state management for signing Up with the SignUp component.
** Problems solved**
1. Now the SignUp button successfully makes the IsLoggedIn state variable as true on clicking and navigates to the "/plan" route.
2.  The HeroSection can be now modified easily with the Hero component under components directory without touching the SignUp and login components.
3.  The responsiveness of the SignUp page is fixed as it used to overlap with the Navbar that now is clean.

https://github.com/user-attachments/assets/a291c2f8-b4b4-4364-805c-b0e32aed43ff


issue fixed : #43 