### PR TITLE
feat: Added dark mode toggle and styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.11.0",
         "chart.js": "^4.5.0",
         "cors": "^2.8.5",
+        "firebase": "^12.1.0",
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.536.0",
         "react": "^18.2.0",
@@ -2470,6 +2471,620 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.1.0.tgz",
+      "integrity": "sha512-4HvFr4YIzNFh0MowJLahOjJDezYSTjQar0XYVu/sAycoxQ+kBsfXuTPRLVXCYfMR5oNwQgYe4Q2gAOYKKqsOyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.18.tgz",
+      "integrity": "sha512-iN7IgLvM06iFk8BeFoWqvVpRFW3Z70f+Qe2PfCJ7vPIgLPjHXDE774DhCT5Y2/ZU/ZbXPDPD60x/XPWEoZLNdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.24.tgz",
+      "integrity": "sha512-jE+kJnPG86XSqGQGhXXYt1tpTbCTED8OQJ/PQ90SEw14CuxRxx/H+lFbWA1rlFtFSsTCptAJtgyRBwr/f00vsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.18",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.1.tgz",
+      "integrity": "sha512-jxTrDbxnGoX7cGz7aP9E7v9iKvBbQfZ8Gz4TH3SfrrkcyIojJM3+hJnlbGnGxHrABts844AxRcg00arMZEyA6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.0.tgz",
+      "integrity": "sha512-XAvALQayUMBJo58U/rxW02IhsesaxxfWVmVkauZvGEz3vOAjMEQnzFlyblqkc2iAaO82uJ2ZVyZv9XzPfxjJ6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.0.tgz",
+      "integrity": "sha512-UfK2Q8RJNjYM/8MFORltZRG9lJj11k0nW84rrffiKvcJxLf1jf6IEjCIkCamykHE73C6BwqhVfhIBs69GXQV0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.1.tgz",
+      "integrity": "sha512-BEy1L6Ufd85ZSP79HDIv0//T9p7d5Bepwy+2mKYkgdXBGKTbFm2e2KxyF1nq4zSQ6RRBxWi0IY0zFVmoBTZlUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.0.tgz",
+      "integrity": "sha512-J0lGSxXlG/lYVi45wbpPhcWiWUMXevY4fvLZsN1GHh+po7TZVng+figdHBVhFheaiipU8HZyc7ljw1jNojM2nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.11.0",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/@firebase/auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.11.0.tgz",
+      "integrity": "sha512-5j7+ua93X+IRcJ1oMDTClTo85l7Xe40WSkoJ+shzPrX7OISlVWLdE1mKC57PSD+/LfAbdhJmvKixINBw2ESK6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
+      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
+      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.11.tgz",
+      "integrity": "sha512-G258eLzAD6im9Bsw+Qm1Z+P4x0PGNQ45yeUuuqe5M9B1rn0RJvvsQCRHXgE52Z+n9+WX1OJd/crcuunvOGc7Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
+      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
+      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-types": "1.0.16",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
+      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.3",
+        "@firebase/util": "1.13.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.9.0.tgz",
+      "integrity": "sha512-5zl0+/h1GvlCSLt06RMwqFsd7uqRtnNZt4sW99k2rKRd6k/ECObIWlEnvthm2cuOSnUmwZknFqtmd1qyYSLUuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "@firebase/webchannel-wrapper": "1.0.4",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.0.tgz",
+      "integrity": "sha512-4O7v4VFeSEwAZtLjsaj33YrMHMRjplOIYC2CiYsF6o/MboOhrhe01VrTt8iY9Y5EwjRHuRz4pS6jMBT8LfQYJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/firestore": "4.9.0",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.0.tgz",
+      "integrity": "sha512-2/LH5xIbD8aaLOWSFHAwwAybgSzHIM0dB5oVOL0zZnxFG1LctX2bc1NIAaPk1T+Zo9aVkLKUlB5fTXTkVUQprQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.0.tgz",
+      "integrity": "sha512-VPgtvoGFywWbQqtvgJnVWIDFSHV1WE6Hmyi5EGI+P+56EskiGkmnw6lEqc/MEUfGpPGdvmc4I9XMU81uj766/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/functions": "0.13.0",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.19.tgz",
+      "integrity": "sha512-nGDmiwKLI1lerhwfwSHvMR9RZuIH5/8E3kgUWnVRqqL7kGVSktjLTWEMva7oh5yxQ3zXfIlIwJwMcaM5bK5j8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.19.tgz",
+      "integrity": "sha512-khfzIY3EI5LePePo7vT19/VEIH1E3iYsHknI/6ek9T8QCozAZshWT9CjlwOzZrKvTHMeNcbpo/VSOSIWDSjWdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.23.tgz",
+      "integrity": "sha512-cfuzv47XxqW4HH/OcR5rM+AlQd1xL/VhuaeW/wzMW1LFrsFcTn0GND/hak1vkQc2th8UisBcrkVcQAnOnKwYxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.23.tgz",
+      "integrity": "sha512-SN857v/kBUvlQ9X/UjAqBoQ2FEaL1ZozpnmL1ByTe57iXkmnVVFm9KqAsTfmf+OEwWI4kJJe9NObtN/w22lUgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.9.tgz",
+      "integrity": "sha512-UzybENl1EdM2I1sjYm74xGt/0JzRnU/0VmfMAKo2LSpHJzaj77FCLZXmYQ4oOuE+Pxtt8Wy2BVJEENiZkaZAzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.22.tgz",
+      "integrity": "sha512-xLKxaSAl/FVi10wDX/CHIYEUP13jXUjinL+UaNXT9ByIvxII5Ne5150mx6IgM8G6Q3V+sPiw9C8/kygkyHUVxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/performance": "0.7.9",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance/node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.6.6.tgz",
+      "integrity": "sha512-Yelp5xd8hM4NO1G1SuWrIk4h5K42mNwC98eWZ9YLVu6Z0S6hFk1mxotAdCRmH2luH8FASlYgLLq6OQLZ4nbnCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.19.tgz",
+      "integrity": "sha512-y7PZAb0l5+5oIgLJr88TNSelxuASGlXyAKj+3pUc4fDuRIdPNBoONMHaIUa9rlffBR5dErmaD2wUBJ7Z1a513Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/remote-config": "0.6.6",
+        "@firebase/remote-config-types": "0.4.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
+      "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.0.tgz",
+      "integrity": "sha512-xWWbb15o6/pWEw8H01UQ1dC5U3rf8QTAzOChYyCpafV6Xki7KVp3Yaw2nSklUwHEziSWE9KoZJS7iYeyqWnYFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.0.tgz",
+      "integrity": "sha512-vDzhgGczr1OfcOy285YAPur5pWDEvD67w4thyeCUh6Ys0izN9fNYtA1MJERmNBfqjqu0lg0FM5GLbw0Il21M+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/storage": "0.14.0",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
+      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.4.tgz",
+      "integrity": "sha512-6m8+P+dE/RPl4OPzjTxcTbQ0rGeRyeTvAi9KwIffBVCiAMKrfXfLZaqD1F+m8t4B5/Q5aHsMozOgirkH1F5oMQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@google/generative-ai": {
       "version": "0.24.1",
       "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
@@ -2477,6 +3092,78 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3881,6 +4568,70 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
@@ -9450,6 +10201,66 @@
         "node": ">=8"
       }
     },
+    "node_modules/firebase": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.1.0.tgz",
+      "integrity": "sha512-oZucxvfWKuAW4eHHRqGKzC43fLiPqPwHYBHPRNsnkgonqYaq0VurYgqgBosRlEulW+TWja/5Tpo2FpUU+QrfEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.1.0",
+        "@firebase/analytics": "0.10.18",
+        "@firebase/analytics-compat": "0.2.24",
+        "@firebase/app": "0.14.1",
+        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check-compat": "0.4.0",
+        "@firebase/app-compat": "0.5.1",
+        "@firebase/app-types": "0.9.3",
+        "@firebase/auth": "1.11.0",
+        "@firebase/auth-compat": "0.6.0",
+        "@firebase/data-connect": "0.3.11",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-compat": "2.1.0",
+        "@firebase/firestore": "4.9.0",
+        "@firebase/firestore-compat": "0.4.0",
+        "@firebase/functions": "0.13.0",
+        "@firebase/functions-compat": "0.4.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/installations-compat": "0.2.19",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/messaging-compat": "0.2.23",
+        "@firebase/performance": "0.7.9",
+        "@firebase/performance-compat": "0.2.22",
+        "@firebase/remote-config": "0.6.6",
+        "@firebase/remote-config-compat": "0.2.19",
+        "@firebase/storage": "0.14.0",
+        "@firebase/storage-compat": "0.4.0",
+        "@firebase/util": "1.13.0"
+      }
+    },
+    "node_modules/firebase/node_modules/@firebase/auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.11.0.tgz",
+      "integrity": "sha512-5j7+ua93X+IRcJ1oMDTClTo85l7Xe40WSkoJ+shzPrX7OISlVWLdE1mKC57PSD+/LfAbdhJmvKixINBw2ESK6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -14307,6 +15118,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -14336,6 +15153,12 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -16804,6 +17627,30 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
+      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "axios": "^1.11.0",
     "chart.js": "^4.5.0",
     "cors": "^2.8.5",
+    "firebase": "^12.1.0",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.536.0",
     "react": "^18.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,9 @@
 
 import React, { useState } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
-import Navbar from "./Components/Navbar";
+import { ThemeProvider } from './context/ThemeContext'; // Import the ThemeProvider
 
+import Navbar from "./Components/Navbar";
 import HomeSplit from "./pages/HomeSplit";
 import PlanTrip from "./pages/PlanTrip";
 import ExpenseTracker from "./pages/ExpenseTracker";
@@ -11,8 +12,6 @@ import Login from "./pages/login";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import TripRecommender from "./pages/TripRecommender";
-
-
 import "./index.css";
 import Footer from "./Components/Footer";
 import Signup from "./pages/Signup";
@@ -22,35 +21,39 @@ function App() {
   const [searchQuery, setSearchQuery] = useState("");
 
   return (
-    <>
-      <Navbar isLoggedIn={isLoggedIn} searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
+    // 1. Wrap the entire application with ThemeProvider
+    // This allows all child components to access the theme context.
+    <ThemeProvider>
+      {/* React Fragment shorthand */}
+      <>
+        <Navbar isLoggedIn={isLoggedIn} searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
 
-      {/* 🧱 Add padding to prevent content being hidden behind navbar */}
-      <div className="pt-20"> {/* Adjust based on navbar height */}
-        <Routes>
-          {/* <Route path="/" element={<HomeSplit setIsLoggedIn={setIsLoggedIn} />} /> */}
-           {/* <Route path="/" element={<><HomeSplit setIsLoggedIn={setIsLoggedIn}/><Signup setIsLoggedIn={setIsLoggedIn} /> </>} /> */}
-           <Route path="/" element={<>< Signup setIsLoggedIn={setIsLoggedIn} /> </>} />
-          <Route path="/login" element={<Login setIsLoggedIn={setIsLoggedIn} />} />
-          <Route path="/plan" element={isLoggedIn ? <PlanTrip searchQuery={searchQuery} /> : <Navigate to="/login" />} />
-          <Route path="/expenses" element={isLoggedIn ? <ExpenseTracker /> : <Navigate to="/login" />} />
-          <Route path="/api/chat" element={isLoggedIn ? <ChatBot /> : <Navigate to="/login" />} />
-          <Route path="/TripRecommender" element={isLoggedIn ? <TripRecommender /> : <Navigate to="/login" />} />
-          <Route path="*" element={<Navigate to="/" />} />
-        </Routes>
+        {/* 🧱 Add padding to prevent content being hidden behind navbar */}
+        <div className="pt-20"> {/* Adjust based on navbar height */}
+          <Routes>
+            {/* <Route path="/" element={<HomeSplit setIsLoggedIn={setIsLoggedIn} />} /> */}
+              {/* <Route path="/" element={<><HomeSplit setIsLoggedIn={setIsLoggedIn}/><Signup setIsLoggedIn={setIsLoggedIn} /> </>} /> */}
+              <Route path="/" element={<>< Signup setIsLoggedIn={setIsLoggedIn} /> </>} />
+            <Route path="/login" element={<Login setIsLoggedIn={setIsLoggedIn} />} />
+            <Route path="/plan" element={isLoggedIn ? <PlanTrip searchQuery={searchQuery} /> : <Navigate to="/login" />} />
+            <Route path="/expenses" element={isLoggedIn ? <ExpenseTracker /> : <Navigate to="/login" />} />
+            <Route path="/api/chat" element={isLoggedIn ? <ChatBot /> : <Navigate to="/login" />} />
+            <Route path="/TripRecommender" element={isLoggedIn ? <TripRecommender /> : <Navigate to="/login" />} />
+            <Route path="*" element={<Navigate to="/" />} />
+          </Routes>
 
-        <Footer isLoggedIn={isLoggedIn} />
-      </div>
+          <Footer isLoggedIn={isLoggedIn} />
+        </div>
 
-      <ToastContainer
-        position="bottom-left"
-        autoClose={3000}
-        pauseOnHover
-        theme="colored"
-      />
-    </>
+        <ToastContainer
+          position="bottom-left"
+          autoClose={3000}
+          pauseOnHover
+          theme="colored"
+        />
+      </>
+    </ThemeProvider>
   );
 }
-
 
 export default App;

--- a/src/Components/Card.jsx
+++ b/src/Components/Card.jsx
@@ -1,55 +1,59 @@
 import React, { useState } from 'react';
+import { useTheme } from '../context/ThemeContext';
 import './Card.css';
 
 const Card = (props) => {
-    const [readmore, setReadmore] = useState(false);
-    const tour = props.tour;
+  const { theme } = useTheme();
+  const [readmore, setReadmore] = useState(false);
+  const tour = props.tour;
 
-    let description = readmore
-        ? tour.info
-        : `${tour.info.substring(0, 200)}....`;
+  let description = readmore
+    ? tour.info
+    : `${tour.info.substring(0, 200)}....`;
 
-    return (
-        <div className="tour-card">
-            <div className="image-wrapper">
-                <img className='cityImage' src={tour.image} alt="cityImage" />
-                <div className="price-tag">{tour.price}</div>
-            </div>
+  return (
+    <div className={`tour-card ${theme === 'dark' ? 'dark-theme-card' : ''}`}>
+      <div className="image-wrapper">
+        <img className='cityImage' src={tour.image} alt="cityImage" />
+        <div className="price-tag">{tour.price}</div>
+      </div>
 
-            <div className="tourInfo">
-                <h4 className="tourCityName">
-                    {tour.emoji} {tour.name} 
-                    <span className="region">({tour.region})</span>
-                </h4>
+      <div className="tourInfo">
+        <h4 className={`tourCityName ${theme === 'dark' ? 'dark-text' : ''}`}>
+          {tour.emoji} {tour.name}
+          <span className={`region ${theme === 'dark' ? 'dark-text-secondary' : ''}`}>({tour.region})</span>
+        </h4>
 
-                <div className="description">
-                    {description}
-                    <span
-                        className='readMore'
-                        onClick={() => setReadmore(!readmore)}
-                    >
-                        {readmore ? " Show Less" : " Read More"}
-                    </span>
-                </div>
-            </div>
-
-            <div className='cardActions'>
-                <button
-                    className='interestedBtn'
-                    onClick={() => props.addToInterested && props.addToInterested(tour)}
-                >
-                    ❤️ Interested
-                </button>
-
-                <button
-                    className='notInterestedBtn'
-                    onClick={() => props.getRemoveId(tour.id)}
-                >
-                    ❌ Not Interested
-                </button>
-            </div>
+        <div className="description">
+          <p className={theme === 'dark' ? 'dark-text-secondary' : ''}>
+            {description}
+            <span
+              className={`readMore ${theme === 'dark' ? 'dark-link-text' : ''}`}
+              onClick={() => setReadmore(!readmore)}
+            >
+              {readmore ? " Show Less" : " Read More"}
+            </span>
+          </p>
         </div>
-    );
+      </div>
+
+      <div className='cardActions'>
+        <button
+          className='interestedBtn'
+          onClick={() => props.addToInterested && props.addToInterested(tour)}
+        >
+          ❤️ Interested
+        </button>
+
+        <button
+          className='notInterestedBtn'
+          onClick={() => props.getRemoveId(tour.id)}
+        >
+          ❌ Not Interested
+        </button>
+      </div>
+    </div>
+  );
 };
 
 export default Card;

--- a/src/Components/Footer.jsx
+++ b/src/Components/Footer.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { useTheme } from '../context/ThemeContext'; // Import the useTheme hook
 import './Footer.css';
 
 const Footer = ({ isLoggedIn }) => {
   const navigate = useNavigate();
+  // Use the custom hook to get the current theme
+  const { theme } = useTheme();
 
   // 🔐 Intercept protected link clicks if not logged in
   const handleProtectedClick = (e, path) => {
@@ -14,7 +17,8 @@ const Footer = ({ isLoggedIn }) => {
   };
 
   return (
-    <footer className="footer">
+    // Conditionally add a 'dark-theme' class based on the current theme
+    <footer className={`footer ${theme === 'dark' ? 'dark-theme-footer' : ''}`}>
       <div className="footer-container">
         <div className="footer-content">
           {/* Brand Section */}

--- a/src/Components/Hero.jsx
+++ b/src/Components/Hero.jsx
@@ -1,18 +1,27 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import { useTheme } from '../context/ThemeContext'; // Import the useTheme hook
 
 export default function HeroSection({ navigateTo }) {
+  // Use the custom hook to get the current theme
+  const { theme } = useTheme();
   const navigate = useNavigate();
 
   const handleStartPlanningClick = () => {
-    navigate(navigateTo || "/login");  // Navigate to the given path or default to home
+    navigate(navigateTo || "/login"); // Navigate to the given path or default to home
   };
 
   return (
-   <><div className="hero-box">
-            <h1>Plan Your Next Adventure</h1>
-            <p>Discover amazing places and create unforgettable memories.</p>
-            <button onClick={handleStartPlanningClick}>Start Planning →</button>
-          </div></>
+    // Add Tailwind dark mode classes to the main container
+    <div className="hero-box bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 p-8 rounded-lg shadow-xl transition-colors duration-300">
+      <h1 className="text-4xl md:text-5xl font-bold mb-4">Plan Your Next Adventure</h1>
+      <p className="text-lg mb-6 text-gray-700 dark:text-gray-300">Discover amazing places and create unforgettable memories.</p>
+      <button 
+        onClick={handleStartPlanningClick}
+        className="px-8 py-3 bg-blue-600 text-white font-semibold rounded-full shadow-lg hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-400 transition duration-300"
+      >
+        Start Planning →
+      </button>
+    </div>
   );
 }

--- a/src/Components/Navbar.jsx
+++ b/src/Components/Navbar.jsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { FaMapMarkedAlt, FaSuitcase, FaMoneyBillWave, FaRobot, FaPlaneDeparture } from "react-icons/fa";
+import { useTheme } from '../context/ThemeContext'; // Import the useTheme hook
 
 const Navbar = ({ isLoggedIn, searchQuery, setSearchQuery }) => {
   const navigate = useNavigate();
+  // Use the custom hook to get the current theme and the toggle function
+  const { theme, toggleTheme } = useTheme();
 
   const handleLogout = () => {
     localStorage.removeItem("token");
@@ -12,15 +15,15 @@ const Navbar = ({ isLoggedIn, searchQuery, setSearchQuery }) => {
   };
 
   return (
-    <nav className=" navbar flex items-center justify-between px-6 py-4 bg-white shadow-md font-inter">
+    <nav className="navbar flex items-center justify-between px-6 py-4 bg-white dark:bg-gray-900 shadow-md font-inter transition-colors duration-300">
       {/* 🔰 Brand Logo */}
-      <div className="flex items-center gap-2 text-2xl font-bold text-blue-600">
+      <div className="flex items-center gap-2 text-2xl font-bold text-blue-600 dark:text-blue-400">
         <FaMapMarkedAlt className="text-3xl" />
         <Link to="/">YourTripPlanner</Link>
       </div>
 
       {/* 🔷 Right: Navigation Links */}
-      <div className="flex space-x-6 items-center text-gray-700 font-medium">
+      <div className="flex space-x-6 items-center text-gray-700 dark:text-gray-300 font-medium">
         {isLoggedIn ? (
           <>
             <input 
@@ -28,18 +31,36 @@ const Navbar = ({ isLoggedIn, searchQuery, setSearchQuery }) => {
               placeholder="Search by city name..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="px-4 py-2 border rounded-full focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="px-4 py-2 border rounded-full focus:outline-none focus:ring-2 focus:ring-blue-500 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 transition-colors duration-300"
             />
-            <Link to="/plan" className="hover:text-blue-600 transition duration-200 flex items-center gap-1">
+            {/* Dark Mode Toggle Button */}
+            <button
+              onClick={toggleTheme}
+              className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-300 focus:outline-none"
+            >
+              {theme === 'light' ? (
+                // Sun Icon (visible in light mode)
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                </svg>
+              ) : (
+                // Moon Icon (visible in dark mode)
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                </svg>
+              )}
+            </button>
+
+            <Link to="/plan" className="hover:text-blue-600 dark:hover:text-blue-400 transition duration-200 flex items-center gap-1">
               <FaSuitcase /> Plan Trip
             </Link>
-            <Link to="/expenses" className="hover:text-blue-600 transition duration-200 flex items-center gap-1">
+            <Link to="/expenses" className="hover:text-blue-600 dark:hover:text-blue-400 transition duration-200 flex items-center gap-1">
               <FaMoneyBillWave /> Expenses
             </Link>
-            <Link to="/api/chat" className="hover:text-blue-600 transition duration-200 flex items-center gap-1">
+            <Link to="/api/chat" className="hover:text-blue-600 dark:hover:text-blue-400 transition duration-200 flex items-center gap-1">
               <FaRobot /> AI Assistant
             </Link>
-            <Link to="/TripRecommender" className="hover:text-blue-600 transition duration-200 flex items-center gap-1">
+            <Link to="/TripRecommender" className="hover:text-blue-600 dark:hover:text-blue-400 transition duration-200 flex items-center gap-1">
               <FaPlaneDeparture /> Trip Recommender
             </Link>
 

--- a/src/Components/Refresh.jsx
+++ b/src/Components/Refresh.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { useTheme } from '../context/ThemeContext';
 
 const Refresh = (props) => {
+  const { theme } = useTheme();
+
   return (
-    <div className="refresh">
+    <div className={`refresh ${theme === 'dark' ? 'dark-theme-refresh' : ''}`}>
       <h2>No tour left</h2>
       <button
         className="refreshBtn"

--- a/src/Components/Tours.css
+++ b/src/Components/Tours.css
@@ -1,0 +1,44 @@
+/* Light Theme Styles */
+.toursWrapper {
+  padding-top: 2rem;
+  background-color: #f8f9fa;
+  color: #212529;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.cardsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  justify-items: center;
+}
+
+.interested-tours-section {
+  padding: 2rem;
+  background-color: #ffffff;
+  color: #212529;
+  border-radius: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  margin-top: 2rem;
+  transition: all 0.3s ease;
+}
+
+/* Dark Theme Styles */
+.dark-theme-tours.toursWrapper {
+  background-color: #1a202c;
+  color: #e2e8f0;
+}
+
+.dark-theme-tours .interested-tours-section {
+  background-color: #2d3748;
+  color: #e2e8f0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.dark-theme-tours .interested-tours-section h3 {
+  color: #ffffff;
+}
+
+.dark-theme-tours .interested-tours-section p {
+  color: #a0aec0;
+}

--- a/src/Components/Tours.jsx
+++ b/src/Components/Tours.jsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import Card from './Card.jsx';
+import { useTheme } from '../context/ThemeContext'; // Import the useTheme hook
+import './Tours.css'; // Assuming Tours.css exists for styling
 
 const Tours = ({ tours, removeTour }) => {
+  const { theme } = useTheme(); // Use the custom hook to get the current theme
   const [interestedTours, setInterestedTours] = useState(() => {
     const saved = localStorage.getItem('interestedTours');
       return saved ? JSON.parse(saved) : [];
@@ -16,36 +19,36 @@ const Tours = ({ tours, removeTour }) => {
     setInterestedTours(prev => prev.filter(tour => tour.id !== id));
   };
 
-// Handler to add a tour to "Interested"
-const handleAddToInterested = (tour) => {
-  if (!interestedTours.find(t => t.id === tour.id)) {
-    setInterestedTours([...interestedTours, tour]);
-  }
-};
+  // Handler to add a tour to "Interested"
+  const handleAddToInterested = (tour) => {
+    if (!interestedTours.find(t => t.id === tour.id)) {
+      setInterestedTours([...interestedTours, tour]);
+    }
+  };
 
   return (
-    <div className="toursWrapper">
+    // Add a conditional class for dark mode
+    <div className={`toursWrapper ${theme === 'dark' ? 'dark-theme-tours' : ''}`}>
       <div className="cardsGrid">
         {tours.map((tour) => (
           <Card 
-          addToInterested={handleAddToInterested}
-          key={tour.id} 
-          tour={tour} 
-          getRemoveId={getId} 
+            addToInterested={handleAddToInterested}
+            key={tour.id} 
+            tour={tour} 
+            getRemoveId={getId}
+            theme={theme} // Pass the theme prop to the Card component
           />
         ))}
       </div>
 
-      <div>
-        <h3>Interested Tours</h3>
-        {interestedTours.length === 0 && <p>No tours marked as interested yet.</p>}
+      <div className="interested-tours-section">
+        <h3 className="text-xl font-bold mb-2">Interested Tours</h3>
+        {interestedTours.length === 0 && <p className="text-gray-600 dark:text-gray-400">No tours marked as interested yet.</p>}
         {interestedTours.map(tour => (
-          <div key={tour.id}>{tour.name}</div>
+          <div key={tour.id} className="p-2 border-b border-gray-200 dark:border-gray-700">{tour.name}</div>
         ))}
       </div>
     </div>
-
-    
   );
 };
 

--- a/src/Components/tripRecommender.css
+++ b/src/Components/tripRecommender.css
@@ -1,9 +1,41 @@
+/* Light Theme Styles */
+.trip-recommender-container {
+  padding-top: 100px;
+  min-height: 100vh;
+  background-color: #f8f9fa;
+  color: #212529;
+  transition: background-color 0.3s ease, color 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-family: 'Inter', sans-serif;
+  padding: 2rem;
+}
 
-
-.trip-recommender h2 {
+.trip-recommender-header {
   text-align: center;
-  font-size: 2rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.trip-recommender-title {
+  font-size: 2.5rem;
+  font-weight: bold;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  color: #000;
+}
+
+.trip-recommender-subtitle {
+  font-size: 1.25rem;
+  color: #6c757d;
+  margin-top: 0.5rem;
+}
+
+.trip-recommender-icon {
+  color: #28a745;
+  font-size: 2.5rem;
 }
 
 .filters {
@@ -11,98 +43,234 @@
   flex-wrap: wrap;
   gap: 1rem;
   justify-content: center;
-  align-items: center;
+  align-items: flex-end;
   margin-bottom: 2rem;
+  width: 100%;
+  max-width: 800px;
 }
 
-.filters label {
-  font-weight: 500;
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 150px;
 }
 
-.filters select {
-  padding: 0.5rem;
-  border-radius: 8px;
-  border: 1px solid #ccc;
-  font-size: 1rem;
+.filter-group label {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  color: #000;
 }
 
-.filters button {
-  padding: 0.6rem 1.2rem;
-  background-color: #4caf50;
-  color: white;
-  border: none;
-  border-radius: 8px;
+.filter-group select {
+  padding: 0.75rem;
+  border: 1px solid #ced4da;
+  border-radius: 0.5rem;
+  background-color: #fff;
+  color: #212529;
   font-size: 1rem;
   cursor: pointer;
-  transition: background 0.3s ease;
 }
 
-.filters button:hover {
-  background-color: #388e3c;
+.filter-button {
+  padding: 0.75rem 1.5rem;
+  background-color: #28a745;
+  color: #ffffff;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: background-color 0.3s ease;
+}
+
+.filter-button:hover {
+  background-color: #218838;
 }
 
 .results {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
-  padding: 1rem 0;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+  justify-items: center;
+  width: 100%;
+  max-width: 1100px;
 }
 
 .place-card {
   background: #fff;
   border-radius: 12px;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.06);
-  transition: transform 0.3s ease;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  overflow: hidden;
 }
 
 .place-card:hover {
   transform: translateY(-5px);
-}
-
-.card {
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12);
 }
 
 .cityImage {
   width: 100%;
   height: 200px;
   object-fit: cover;
-  border-bottom: 1px solid #eee;
 }
 
 .tourInfo {
-  padding: 1rem;
+  padding: 1.5rem;
 }
 
-.tourPrice {
-  color: green;
-  margin: 0 0 0.5rem 0;
-  font-weight: bold;
-}
-
-.tourCityName {
-  margin: 0.5rem 0;
-  font-size: 1.2rem;
-}
-
-.tourDetails {
+.tourHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: 0.5rem;
 }
 
-p {
-  margin: 0.5rem 0;
-  font-size: 0.95rem;
-  color: #444;
+.tourPrice {
+  color: #28a745;
+  font-weight: bold;
+  font-size: 1.25rem;
 }
 
-small {
-  color: #666;
-  font-size: 0.85rem;
+.tourCityName {
+  font-size: 1.25rem;
+  font-weight: bold;
+  color: #212529;
 }
-.trip-recommender {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 2rem 1rem;
+
+.region {
+  font-size: 0.9rem;
+  font-weight: normal;
+  color: #6c757d;
+}
+
+.tourDetails {
+  font-size: 0.95rem;
+  color: #444;
+  line-height: 1.5;
+  margin-bottom: 1rem;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag {
+  font-size: 0.8rem;
+  font-weight: bold;
+  padding: 0.25rem 0.75rem;
+  border-radius: 1rem;
+}
+
+.tag-mood {
+  background-color: #e6f7ff;
+  color: #007bff;
+}
+
+.tag-purpose {
+  background-color: #e9f5e9;
+  color: #28a745;
+}
+
+.no-recommendations {
+  text-align: center;
+  color: #6c757d;
+  font-style: italic;
+  font-size: 1.1rem;
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 4rem 0;
+}
+
+.compass-icon {
+  font-size: 3rem;
+  color: #ced4da;
+}
+
+/* Dark Theme Overrides */
+.dark-theme-recommender.trip-recommender-container {
+  background-color: #1a202c;
+  color: #e2e8f0;
+}
+
+.dark-theme-recommender .trip-recommender-title {
+  color: #fff;
+}
+
+.dark-theme-recommender .trip-recommender-subtitle {
+  color: #a0aec0;
+}
+
+.dark-theme-recommender .trip-recommender-icon {
+  color: #68d391;
+}
+
+.dark-theme-recommender .filter-group label {
+  color: #fff;
+}
+
+.dark-theme-recommender .filter-group select {
+  background-color: #2d3748;
+  color: #e2e8f0;
+  border-color: #4a5568;
+}
+
+.dark-theme-recommender .filter-button {
+  background-color: #48bb78;
+}
+
+.dark-theme-recommender .filter-button:hover {
+  background-color: #38a169;
+}
+
+.dark-theme-recommender .place-card {
+  background: #2d3748;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+}
+
+.dark-theme-recommender .place-card:hover {
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.6);
+}
+
+.dark-theme-recommender .tourCityName {
+  color: #fff;
+}
+
+.dark-theme-recommender .tourPrice {
+  color: #68d391;
+}
+
+.dark-theme-recommender .region {
+  color: #a0aec0;
+}
+
+.dark-theme-recommender .tourDetails {
+  color: #a0aec0;
+}
+
+.dark-theme-recommender .tags .tag-mood {
+  background-color: #2c5282;
+  color: #90cdf4;
+}
+
+.dark-theme-recommender .tags .tag-purpose {
+  background-color: #38a169;
+  color: #fff;
+}
+
+.dark-theme-recommender .no-recommendations {
+  color: #a0aec0;
+}
+
+.dark-theme-recommender .compass-icon {
+  color: #4a5568;
 }

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+// 1. Create a new Theme Context
+// This will be the central place to store our theme state and toggle function.
+const ThemeContext = createContext();
+
+// 2. Create the ThemeProvider component
+// This component will wrap your entire application and provide the theme context to all children.
+export const ThemeProvider = ({ children }) => {
+  // Use a state variable to hold the current theme ('light' or 'dark').
+  const [theme, setTheme] = useState('light');
+
+  // This useEffect runs once on the initial component mount to check for a saved theme
+  // in local storage or the user's system preference.
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme');
+    // If a theme is saved, use that.
+    if (savedTheme) {
+      setTheme(savedTheme);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      // Otherwise, check for the user's system preference.
+      setTheme('dark');
+    }
+  }, []);
+
+  // This useEffect runs whenever the 'theme' state changes.
+  // It adds or removes the 'dark' class from the root <html> element,
+  // which is how Tailwind CSS knows to apply its dark mode styles.
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [theme]);
+
+  // The function to toggle the theme. It updates the state and also saves the preference
+  // to local storage so the theme persists across page refreshes.
+  const toggleTheme = () => {
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+  };
+
+  // Provide the theme and the toggle function to the rest of the application.
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+// 3. Create a custom hook to use the theme context
+// This hook provides a convenient way for any component to access the theme state and toggle function.
+export const useTheme = () => useContext(ThemeContext);

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,0 +1,18 @@
+import { initializeApp } from "firebase/app";
+import { getAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
+
+const firebaseConfig = {
+  apiKey: "AIzaSyCiVjM54cFxvjOf-1Egqhr3XrlCNu_I3WQ",
+  authDomain: "trip-planner-bad2b.firebaseapp.com",
+  projectId: "trip-planner-bad2b",
+  storageBucket: "trip-planner-bad2b.firebasestorage.app",
+  messagingSenderId: "731808227250",
+  appId: "1:731808227250:web:a5e9434d6148c1139b8eab",
+  measurementId: "G-L8FNY7BHSX"
+};
+
+const app = initializeApp(firebaseConfig);
+
+export const auth = getAuth(app);
+export const db = getFirestore(app);

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url("https://fonts.googleapis.com/css2?family=Manrope&family=Montserrat&family=Mulish:ital@1&family=Poppins&family=Raleway&family=Roboto&display=swap");
+
 /* Chat animations */
 @keyframes fadeIn {
   from {
@@ -36,26 +38,63 @@
   background: #94a3b8;
 }
 
-@import url("https://fonts.googleapis.com/css2?family=Manrope&family=Montserrat&family=Mulish:ital@1&family=Poppins&family=Raleway&family=Roboto&display=swap");
-
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
 
-.main-content {
-  padding-top: 80px;
+/* Base theme variables */
+:root {
+  --background-color: #f9f9f9;
+  --text-color: #333333;
+  --card-background: #ffffff;
+  --card-shadow: rgba(0, 0, 0, 0.08);
+  --title-color: #28a745;
+  --border-color: #ccc;
+  --link-color: #007bff;
+  --link-color-dark: #218838;
 }
 
+/* Dark theme overrides */
+.dark {
+  --background-color: #1a202c;
+  --text-color: #e2e8f0;
+  --card-background: #2d3748;
+  --card-shadow: rgba(0, 0, 0, 0.4);
+  --title-color: #68d391;
+  --border-color: #4a5568;
+  --link-color: #63b3ed;
+  --link-color-dark: #3182ce;
+}
 
 body, html, #root {
   margin: 0;
   padding: 0;
   height: 100%;
-  font-family: 'Manrope', sans-serif;
+  font-family: 'Manrope', 'Segoe UI', Roboto, sans-serif;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
+/* 🌍 Global Styles */
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Roboto, sans-serif;
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+h2, h3, h4 {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.main-content {
+  padding-top: 80px;
+}
 
 .container {
   display: flex;
@@ -65,11 +104,12 @@ body, html, #root {
 }
 
 .title {
-  border: 7px #0111a0;
+  border: 7px solid #0111a0;
   border-radius: 20px;
   font-size: 3rem;
   margin: 6vh;
   padding: 1vh 3vw;
+  color: var(--title-color);
 }
 
 .titleWrapper {
@@ -81,6 +121,7 @@ body, html, #root {
   font-size: 3rem;
   font-weight: bold;
   display: inline-block;
+  color: var(--title-color);
 }
 
 .cardsContainer {
@@ -88,16 +129,13 @@ body, html, #root {
   display: flex;
   flex-flow: row wrap;
   justify-content: center;
-  
   margin: 0 auto;
-  
   width:100%;
-  align-items:stretch;  /* ADD THIS */
+  align-items:stretch;
 }
 
 .card {
   width:400px;
-  /* Remove height: max-content; */
   display: flex;
   flex-direction: column;
   padding: 1rem;
@@ -105,7 +143,14 @@ body, html, #root {
   box-shadow: 0px 3px 8px rgba(0, 0, 0, 0.24);
   border-radius: 10px;
   align-items: center;
-  justify-content: flex-start; /* change to flex-start to align content at top */
+  justify-content: flex-start;
+  background-color: var(--card-background);
+  transition: all 0.3s ease;
+  box-shadow: 0 6px 16px var(--card-shadow);
+}
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 10px 20px var(--card-shadow);
 }
 
 
@@ -133,18 +178,18 @@ body, html, #root {
 }
 
 .readMore {
-  color: #12b0e2;
+  color: var(--link-color);
   cursor: pointer;
 }
-{/*Styling the cards */}
 
+/* Styling the cards */
 .cardActions{
   display: flex;
   gap: 10px;
   padding: 10px;
   justify-content: space-between;
-
 }
+
 .intrestedBtn{
   background-color: #47a24a;
   color: white;
@@ -157,7 +202,6 @@ body, html, #root {
   font-size: 15px;
   margin-top: 18px;
   transition: all 0.4s
-
 }
 .intrestedBtn:hover{
   background-color: green;
@@ -170,7 +214,6 @@ body, html, #root {
   border: none;
   padding: 10px 20px;
   border-radius: 5px;
-  /* text-align: center; */
   font-weight: bold;
   font-size: 15px;
   cursor: pointer;
@@ -206,27 +249,26 @@ body, html, #root {
 .regionFilters {
   margin: 1rem 0;
   text-align: center;
-  
 }
 
 .regionBtn {
-  padding: 0.5rem 1rem;
-  margin: 0 0.5rem 0.5rem;
-  background-color: #eee;
+  background-color: #28a745;
+  color: #fff;
   border: none;
-  border-radius: 20px;
+  padding: 0.6rem 1.4rem;
+  font-weight: 500;
+  border-radius: 8px;
   cursor: pointer;
-  transition: background-color 0.3s;
-
+  transition: all 0.3s ease;
 }
 
 .regionBtn:hover {
-  background-color: #ccc;
+  background-color: #218838;
 }
 
 .regionBtn.active {
-  background-color: #000;
-  color: #fff;
+  background-color: #ffc107;
+  color: #000;
 }
 .regionBtn.active:hover {
   background-color: #333;
@@ -272,157 +314,39 @@ body, html, #root {
 /* Dropdown Menu - Clean and minimal */
 .dropdown-menu {
   position: absolute;
-  top: 100%;
+  top: 110%;
   left: 0;
-  right: 0;
   background-color: white;
   border: 1px solid #ddd;
-  border-radius: 20px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  z-index: 1000;
-  margin-top: 4px;
-  overflow: hidden;
+  border-radius: 5px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  z-index: 10;
+  min-width: 160px;
 }
 
 /* Dropdown Items - Same style as original regionBtn */
 .dropdown-item {
-  display: block;
-  width: 100%;
   padding: 0.5rem 1rem;
-  background-color: transparent;
+  width: 100%;
+  text-align: left;
+  background: none;
   border: none;
-  text-align: center;
   cursor: pointer;
   transition: background-color 0.3s;
   font-size: inherit;
   font-family: inherit;
 }
 
-.dropdown-item:hover {
-  background-color: #ccc;
-}
-
+.dropdown-item:hover,
 .dropdown-item.active {
-  background-color: #000;
-  color: #fff;
+  background-color: #f0f0f0;
 }
 
-.dropdown-item.active:hover {
-  background-color: #333;
-}
-
-/* Responsive Design */
-@media (max-width: 768px) {
-  .controls-container {
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-  }
-}
-
-body, html, #root {
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  font-family: 'Segoe UI', sans-serif;
-}
-/* 🌍 Global Styles */
-body {
-  margin: 0;
-  font-family: 'Segoe UI', Roboto, sans-serif;
-  background-color: #f9f9f9;
-  color: #333;
-}
-
-h2, h3, h4 {
-  margin: 0;
-  font-weight: 600;
-}
-
-/* 🧳 Main Planner Container */
-.plan-trip-container {
-  padding: 2rem;
-  max-width: 1200px;
-  margin: auto;
-}
-
-/* 🎯 Title Styling */
-.titleWrapper {
-  text-align: center;
-  margin-bottom: 2rem;
-}
-
-.title {
-  font-size: 2.4rem;
-  color: #28a745;
-  border-bottom: 2px dashed #ccc;
-  display: inline-block;
-  padding-bottom: 0.5rem;
-}
-
-/* 🌐 Region Filters */
-.regionFilters {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 2rem;
-}
-
-.regionBtn {
-  background-color: #28a745;
-  color: #fff;
-  border: none;
-  padding: 0.6rem 1.4rem;
-  font-weight: 500;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.regionBtn:hover {
-  background-color: #218838;
-}
-
-.regionBtn.active {
-  background-color: #ffc107;
-  color: #000;
-}
-
-/* 📦 Tours Grid */
-.toursWrapper {
-  padding: 1rem 0;
-}
-
-.cardsGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 2rem;
-  justify-items: center;
-}
-
-/* 🗂️ Card Style */
-.card {
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
-  padding: 1.2rem;
-  width: 100%;
-  max-width: 280px;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.card:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12);
-}
-
-/* 🎉 Responsive Tweaks */
+/* Responsive Tweaks */
 @media (max-width: 768px) {
   .title {
     font-size: 2rem;
   }
-
   .regionBtn {
     padding: 0.5rem 1rem;
   }
@@ -451,10 +375,6 @@ h2, h3, h4 {
   gap: 1rem;
   margin-bottom: 2rem;
   flex-wrap: wrap;
-}
-
-.dropdown-container {
-  position: relative;
 }
 
 .dropdown-btn {
@@ -492,5 +412,3 @@ h2, h3, h4 {
 .dropdown-item.active {
   background-color: #f0f0f0;
 }
-
-

--- a/src/pages/ExpenseTracker.css
+++ b/src/pages/ExpenseTracker.css
@@ -1,47 +1,43 @@
-body {
-  margin: 0;
-  font-family: Arial, sans-serif;
-}
-
-
+/* Base Styles for the Expense Tracker page */
 .main {
   position: relative;
   min-height: 100vh;
   padding: 2rem;
-  background: url("https://plus.unsplash.com/premium_photo-1680721442350-6f91fbe7df3f?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D")
-    no-repeat center center/cover;
+  background: url("https://plus.unsplash.com/premium_photo-1680721442350-6f91fbe7df3f?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D") no-repeat center center/cover;
   display: flex;
   flex-direction: column;
   align-items: center;
+  transition: background-color 0.3s ease, color 0.3s ease;
+  font-family: Arial, sans-serif;
 }
 
 .main::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4); /* Dark overlay */
+  background: rgba(0, 0, 0, 0.4);
 }
-
 
 .page-title {
   text-align: center;
-  font-size: 2.4rem;  /* Bigger */
-  font-weight: 800;   /* Bold */
-  color: #111;        /* Dark color */
+  font-size: 2.4rem;
+  font-weight: 800;
+  color: #111;
   margin-bottom: 1.2rem;
 }
 
-
-
-.expense-form-wrapper {
+.expense-form-wrapper, .right-panel {
   max-width: 600px;
   margin: 2rem auto;
   padding: 2rem;
-  background: rgba(255, 255, 255, 0.95); /* Light background */
+  background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(8px);
   border-radius: 16px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-  color: #222; /* Darker text inside */
+  color: #222;
+  transition: all 0.3s ease;
+  position: relative;
+  z-index: 1; /* Ensure content is above the overlay */
 }
 
 .expense-form {
@@ -56,15 +52,15 @@ body {
 .expense-form select {
   padding: 0.6rem 1rem;
   font-size: 1rem;
-  background: #f2f2f2; /* Light grey input */
-  color: #222; /* Dark text */
+  background: #f2f2f2;
+  color: #222;
   border: 1px solid #bbb;
   border-radius: 8px;
   transition: 0.3s;
 }
 
 .expense-form input::placeholder {
-  color: #555; /* Darker placeholder */
+  color: #555;
 }
 
 .expense-form input:focus,
@@ -75,7 +71,8 @@ body {
 }
 
 .expense-form button,
-.analysis-btn {
+.analysis-btn,
+.clear-btn {
   padding: 0.6rem 1.2rem;
   background: linear-gradient(135deg, #4caf50, #2e7d32);
   color: white;
@@ -88,6 +85,9 @@ body {
   align-items: center;
   gap: 0.4rem;
 }
+.clear-btn {
+  background: linear-gradient(135deg, #ff4d4d, #b71c1c);
+}
 
 .expense-form button:hover,
 .analysis-btn:hover {
@@ -95,11 +95,15 @@ body {
   transform: scale(1.05);
 }
 
+.clear-btn:hover {
+  background: linear-gradient(135deg, #e60000, #7f0000);
+}
+
 .total-spent {
   text-align: center;
   font-size: 1.6rem;
   font-weight: 700;
-  color: #111; /* Darker total text */
+  color: #111;
   margin-bottom: 1rem;
 }
 
@@ -113,8 +117,8 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: #f1f1f1; /* Light grey background */
-  color: #222; /* Dark text */
+  background: #f1f1f1;
+  color: #222;
   padding: 0.8rem 1rem;
   margin-bottom: 0.7rem;
   border-radius: 12px;
@@ -163,51 +167,10 @@ body {
   gap: 0.3rem;
 }
 
-.tag.travel {
-  background-color: #1e88e5;
-}
-.tag.food {
-  background-color: #d81b60;
-}
-.tag.stay {
-  background-color: #43a047;
-}
-.tag.misc {
-  background-color: #8e24aa;
-}
-
-.right-panel {
-  max-width: 500px;
-  margin: 2rem auto;
-  padding: 1rem;
-  background: rgba(255, 255, 255, 0.95); /* Same light background */
-  border-radius: 12px;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
-  transition: opacity 0.4s ease;
-  color: #222;
-}
-
-.hidden {
-  opacity: 0;
-  pointer-events: none;
-  transform: scale(0.95);
-}
-
-@media (max-width: 600px) {
-  .expense-form {
-    flex-direction: column;
-    gap: 0.6rem;
-  }
-
-  .expense-list li {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+.tag.travel { background-color: #1e88e5; }
+.tag.food { background-color: #d81b60; }
+.tag.stay { background-color: #43a047; }
+.tag.misc { background-color: #8e24aa; }
 
 .button-group {
   display: flex;
@@ -216,20 +179,53 @@ button:disabled {
   margin-top: 1rem;
 }
 
-.clear-btn {
-  padding: 0.6rem 1.2rem;
-  background: linear-gradient(135deg, #ff4d4d, #b71c1c);
-  color: white;
-  border: none;
-  font-size: 1rem;
-  border-radius: 10px;
-  cursor: pointer;
-  transition: 0.3s;
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
-.clear-btn:hover {
-  background: linear-gradient(135deg, #e60000, #7f0000);
+.hidden {
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0.95);
+}
+
+/* Dark theme styles */
+.dark-theme-expense .main {
+  background: url("https://images.unsplash.com/photo-1518640467707-6811f445f743?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D") no-repeat center center/cover;
+}
+
+.dark-theme-expense .main::before {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.dark-theme-expense .page-title {
+  color: #fff;
+}
+
+.dark-theme-expense .expense-form-wrapper,
+.dark-theme-expense .right-panel {
+  background: rgba(45, 55, 72, 0.9);
+  color: #e2e8f0;
+}
+
+.dark-theme-expense .expense-form input,
+.dark-theme-expense .expense-form select {
+  background: #4a5568;
+  color: #e2e8f0;
+  border-color: #4a5568;
+}
+
+.dark-theme-expense .expense-form input::placeholder {
+  color: #a0aec0;
+}
+
+.dark-theme-expense .total-spent {
+  color: #fff;
+}
+
+.dark-theme-expense .expense-list li {
+  background: #4a5568;
+  color: #e2e8f0;
+  border-color: #4a5568;
 }

--- a/src/pages/ExpenseTracker.jsx
+++ b/src/pages/ExpenseTracker.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 import {
   PieChart,
   Pie,
@@ -10,20 +10,22 @@ import {
   XAxis,
   YAxis,
   Legend,
-} from 'recharts';
-import { FaChartPie, FaChartBar, FaTrash, FaBroom } from 'react-icons/fa';
-import { FaMoneyBillWave } from 'react-icons/fa';
+} from "recharts";
+import { FaChartPie, FaChartBar, FaTrash, FaBroom, FaMoneyBillWave } from "react-icons/fa";
+import { useTheme } from '../context/ThemeContext';
 
-const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7f50', '#ffbb28'];
+const COLORS = ["#8884d8", "#82ca9d", "#ffc658", "#ff7f50", "#ffbb28"];
 
 const ExpenseTracker = () => {
+  const { theme } = useTheme();
   const [expenses, setExpenses] = useState([]);
-  const [item, setItem] = useState('');
-  const [amount, setAmount] = useState('');
-  const [date, setDate] = useState('');
-  const [category, setCategory] = useState('Travel');
-  const [label, setLabel] = useState('');
-  const [chartType, setChartType] = useState('pie');
+  const [item, setItem] = useState("");
+  const [amount, setAmount] = useState("");
+  const [date, setDate] = useState("");
+  const [category, setCategory] = useState("Travel");
+  const [label, setLabel] = useState("");
+  const [chartType, setChartType] = useState("pie");
+  const [showConfirm, setShowConfirm] = useState(false);
 
   const handleAddExpense = () => {
     if (item && amount && date && category) {
@@ -37,11 +39,11 @@ const ExpenseTracker = () => {
           label: label || category,
         },
       ]);
-      setItem('');
-      setAmount('');
-      setDate('');
-      setCategory('Travel');
-      setLabel('');
+      setItem("");
+      setAmount("");
+      setDate("");
+      setCategory("Travel");
+      setLabel("");
     }
   };
 
@@ -50,9 +52,16 @@ const ExpenseTracker = () => {
   };
 
   const handleClearAll = () => {
-    if (window.confirm('Are you sure you want to clear all expenses?')) {
-      setExpenses([]);
-    }
+    setShowConfirm(true);
+  };
+  
+  const confirmClearAll = () => {
+    setExpenses([]);
+    setShowConfirm(false);
+  };
+  
+  const cancelClearAll = () => {
+    setShowConfirm(false);
   };
 
   const totalSpent = expenses.reduce((acc, curr) => acc + curr.amount, 0);
@@ -67,10 +76,10 @@ const ExpenseTracker = () => {
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 p-4">
-      <div className="max-w-3xl mx-auto bg-white rounded-2xl shadow-xl p-8">
+    <div className={`min-h-screen ${theme === 'dark' ? 'bg-gray-950 text-white' : 'bg-gradient-to-br from-purple-100 to-blue-100 text-gray-900'} p-4 transition-colors duration-300`}>
+      <div className={`max-w-3xl mx-auto rounded-2xl shadow-xl p-8 ${theme === 'dark' ? 'bg-gray-800' : 'bg-white'}`}>
         <h1 className="text-3xl font-extrabold flex items-center justify-center gap-3 text-center mb-4">
-          <FaMoneyBillWave className="text-green-600 text-4xl" />
+          <FaMoneyBillWave className="text-green-600 text-4xl dark:text-green-400" />
           Expense Tracker
         </h1>
 
@@ -78,28 +87,28 @@ const ExpenseTracker = () => {
           <input
             type="text"
             placeholder="Expense item"
-            className="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-400"
+            className={`p-3 rounded-lg border focus:outline-none focus:ring-2 focus:ring-purple-400 ${theme === 'dark' ? 'bg-gray-700 text-white border-gray-600' : 'bg-white border-gray-300'}`}
             value={item}
             onChange={(e) => setItem(e.target.value)}
           />
           <input
             type="number"
             placeholder="Amount (₹)"
-            className="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-400"
+            className={`p-3 rounded-lg border focus:outline-none focus:ring-2 focus:ring-purple-400 ${theme === 'dark' ? 'bg-gray-700 text-white border-gray-600' : 'bg-white border-gray-300'}`}
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
             min="0"
           />
           <input
             type="date"
-            className="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-400"
+            className={`p-3 rounded-lg border focus:outline-none focus:ring-2 focus:ring-purple-400 ${theme === 'dark' ? 'bg-gray-700 text-white border-gray-600' : 'bg-white border-gray-300'}`}
             value={date}
             onChange={(e) => setDate(e.target.value)}
           />
           <select
             value={category}
             onChange={(e) => setCategory(e.target.value)}
-            className="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-400"
+            className={`p-3 rounded-lg border focus:outline-none focus:ring-2 focus:ring-purple-400 ${theme === 'dark' ? 'bg-gray-700 text-white border-gray-600' : 'bg-white border-gray-300'}`}
           >
             <option value="Travel">Travel</option>
             <option value="Food">Food</option>
@@ -110,7 +119,7 @@ const ExpenseTracker = () => {
           <input
             type="text"
             placeholder="Label (optional)"
-            className="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-400"
+            className={`p-3 rounded-lg border focus:outline-none focus:ring-2 focus:ring-purple-400 ${theme === 'dark' ? 'bg-gray-700 text-white border-gray-600' : 'bg-white border-gray-300'}`}
             value={label}
             onChange={(e) => setLabel(e.target.value)}
           />
@@ -129,21 +138,21 @@ const ExpenseTracker = () => {
         <div className="mt-10">
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-lg font-semibold flex items-center gap-2">
-              {chartType === 'pie' ? <FaChartPie /> : <FaChartBar />} Analysis
+              {chartType === "pie" ? <FaChartPie /> : <FaChartBar />} Analysis
             </h3>
             <select
               value={chartType}
               onChange={(e) => setChartType(e.target.value)}
-              className="p-2 rounded-md border border-gray-300 focus:outline-none"
+              className={`p-2 rounded-md border focus:outline-none ${theme === 'dark' ? 'bg-gray-700 text-white border-gray-600' : 'bg-white border-gray-300'}`}
             >
               <option value="pie">Pie Chart</option>
               <option value="bar">Bar Chart</option>
             </select>
           </div>
 
-          <div className="h-80 bg-white rounded-xl shadow-md p-4">
+          <div className={`h-80 rounded-xl shadow-md p-4 ${theme === 'dark' ? 'bg-gray-700' : 'bg-white'}`}>
             <ResponsiveContainer width="100%" height="100%">
-              {chartType === 'pie' ? (
+              {chartType === "pie" ? (
                 <PieChart>
                   <Pie
                     data={data}
@@ -163,13 +172,13 @@ const ExpenseTracker = () => {
                       />
                     ))}
                   </Pie>
-                  <Tooltip formatter={(value) => [`₹${value}`, 'Amount']} />
+                  <Tooltip formatter={(value) => [`₹${value}`, "Amount"]} />
                 </PieChart>
               ) : (
                 <BarChart data={data}>
                   <XAxis dataKey="name" />
                   <YAxis />
-                  <Tooltip formatter={(value) => [`₹${value}`, 'Amount']} />
+                  <Tooltip formatter={(value) => [`₹${value}`, "Amount"]} />
                   <Legend />
                   <Bar dataKey="value" fill="#82ca9d" />
                 </BarChart>
@@ -184,7 +193,7 @@ const ExpenseTracker = () => {
             {expenses.length > 0 && (
               <button
                 onClick={handleClearAll}
-                className="flex items-center gap-2 bg-red-500 hover:bg-red-600 text-white px-3 py-2 rounded-md text-sm"
+                className="flex items-center gap-2 bg-red-500 hover:bg-red-600 text-white px-3 py-2 rounded-md text-sm transition"
               >
                 <FaBroom /> Clear All
               </button>
@@ -195,21 +204,21 @@ const ExpenseTracker = () => {
             {expenses.map((exp, idx) => (
               <li
                 key={idx}
-                className="flex justify-between items-center p-3 bg-gray-50 rounded-lg shadow-sm hover:bg-gray-100"
+                className={`flex justify-between items-center p-3 rounded-lg shadow-sm ${theme === 'dark' ? 'bg-gray-700 hover:bg-gray-600' : 'bg-gray-50 hover:bg-gray-100'}`}
               >
                 <div>
                   <p className="font-medium">
                     {exp.item} ({exp.label})
                   </p>
-                  <p className="text-sm text-gray-500">{exp.date}</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">{exp.date}</p>
                 </div>
                 <div className="flex items-center gap-4">
-                  <span className="font-semibold text-green-600">
+                  <span className="font-semibold text-green-600 dark:text-green-400">
                     ₹{exp.amount}
                   </span>
                   <button
                     onClick={() => handleDelete(idx)}
-                    className="text-red-500 hover:text-red-700"
+                    className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-500"
                     title="Delete"
                   >
                     <FaTrash />
@@ -220,8 +229,27 @@ const ExpenseTracker = () => {
           </ul>
         </div>
       </div>
+      
+      {/* Custom Confirmation Modal */}
+      {showConfirm && (
+        <div className="fixed inset-0 bg-gray-600 bg-opacity-50 flex items-center justify-center z-50">
+          <div className={`p-6 rounded-lg shadow-lg ${theme === 'dark' ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'}`}>
+            <h4 className="text-lg font-bold mb-4">Confirm Clear All</h4>
+            <p>Are you sure you want to clear all expenses? This cannot be undone.</p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button onClick={cancelClearAll} className="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded-md hover:bg-gray-400 dark:hover:bg-gray-600 transition">
+                Cancel
+              </button>
+              <button onClick={confirmClearAll} className="px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-600 transition">
+                Clear All
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };
 
 export default ExpenseTracker;
+

--- a/src/pages/HomeSplit.css
+++ b/src/pages/HomeSplit.css
@@ -1,62 +1,82 @@
-/* Full-page background with image */
+/* Base container for the full-page layout */
 .page-background {
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Segoe UI', sans-serif;
+  transition: all 0.3s ease;
   background-image: url('./geojango-maps-CWbbJW_7Fsw-unsplash.jpg');
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
   background-attachment: fixed;
-  height: 100vh;
-  width: 100%;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: 'Segoe UI', sans-serif;
+  padding: 2rem 0; /* Added padding to create space at the top and bottom */
 }
 
-/* Transparent dark overlay */
+/* Dark mode background override */
+.dark-theme-login .page-background,
+.dark-theme-signup .page-background {
+  background-image: url("https://images.unsplash.com/photo-1518640467707-6811f445f743?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D");
+}
+
+/* Semi-transparent overlay */
 .overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
   height: 100%;
   width: 100%;
-  background-color: rgba(0, 0, 0, 0.5); /* semi-transparent black */
+  background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 1;
 }
 
-/* Split layout: left for hero, right for signup */
+/* Split layout: left for hero, right for form */
 .split-content {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 4rem;
+  justify-content: center;
+  align-items: stretch;
   width: 90%;
   max-width: 1200px;
+  min-height: 450px; /* Reduced the minimum height to shrink the container */
   z-index: 2;
   color: white;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
 }
 
-/* Hero Section */
-.hero-box {
+/* Left side styling - Hero Section */
+.hero-section-wrapper {
   flex: 1;
+  background-color: rgba(33, 37, 41, 0.95); /* A near-solid dark background color */
+  padding: 2rem; /* Reduced padding */
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  box-shadow: none;
+}
+
+/* Hero Content */
+.hero-box {
+  width: 100%;
   max-width: 500px;
- 
 }
 
 .hero-box h1 {
-  margin-bottom:1rem;
-  font-size: 3rem;
-  color: #fff;
+  margin-bottom: 1rem; /* Reduced margin */
+  font-size: 2.5rem; /* Reduced font size */
+  color: #000000;
+  font-weight: bold;
 }
 
 .hero-box p {
-  font-size: 1.2rem;
-  margin-bottom: 2rem;
-  color: #eaeaea;
+  font-size: 1.1rem; /* Reduced font size */
+  margin-bottom: 1rem;
+  color: #000000;
 }
 
 .hero-box button {
@@ -75,50 +95,78 @@
   transform: scale(1.05);
 }
 
-/* Signup Form Box */
+/* Right side styling - Login/Signup Form Box */
 .signup-box {
   flex: 1;
-  max-width: 400px;
-  background: rgba(255, 255, 255, 0.9); /* white with transparency */
-  padding: 2rem;
-  border-radius: 16px;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  background-color: #fff;
+  padding: 2rem; /* Reduced padding */
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #000;
+  box-shadow: none;
+}
+
+/* Form Heading */
+.signup-box h2 {
+  margin-bottom: 1rem; /* Reduced margin */
+  font-size: 2.2rem; /* Reduced font size */
+  font-weight: 700;
   color: #000;
 }
 
-/* Form Fields */
+/* Form */
 .signup-form {
+  width: 100%;
+  max-width: 350px;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1rem; /* Reduced gap */
 }
 
-.signup-form h2 {
-  margin-bottom: 1rem;
-  font-size: 2rem;
-  text-align: center;
-}
-
+/* Form Inputs */
 .signup-form input {
-  padding: 0.8rem;
+  padding: 0.8rem; /* Reduced padding */
   border: 1px solid #ccc;
   border-radius: 8px;
-  font-size: 1rem;
+  font-size: 0.9rem; /* Reduced font size */
   outline: none;
-  transition: border 0.3s ease;
+  transition: all 0.3s ease;
 }
 
 .signup-form input:focus {
-  border-color: #ffc107;            /* Yellow border */
-  box-shadow: 0 0 8px #ffc107;      /* Glowing effect */
-  outline: none;
-  transition: 0.3s ease;
+  border-color: #3498db;
+  box-shadow: 0 0 8px rgba(52, 152, 219, 0.4);
+}
+
+/* Password options (Show Password, Forgot Password?) */
+.password-options {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem; /* Reduced font size */
+  margin-top: -0.5rem;
+}
+
+.password-options label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  color: #000000;
+}
+
+.password-options .forgot-password {
+  color: #050606;
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 /* Submit Button */
-.signup-form button {
-  padding: 0.75rem 1.5rem;
-  background-color: #28a745;
+.signup-form button[type="submit"] {
+  padding: 0.6rem 1rem; /* Reduced padding */
+  background-color: #3498db;
   color: white;
   border: none;
   border-radius: 8px;
@@ -127,9 +175,124 @@
   transition: all 0.3s ease;
 }
 
-.signup-form button:hover {
-  background-color: #218838;
-  transform: scale(1.03);
+.signup-form button[type="submit"]:hover {
+  background-color: #2980b9;
+}
+
+/* Divider for "OR" */
+.divider {
+  text-align: center;
+  color: #999;
+  font-weight: 500;
+  position: relative;
+  margin: 0.5rem 0; /* Reduced margin */
+}
+
+.divider::before, .divider::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 40%;
+  height: 1px;
+  background-color: #ddd;
+}
+
+.divider::before { left: 0; }
+.divider::after { right: 0; }
+
+/* Google Button */
+.google-btn {
+  padding: 0.6rem 1rem; /* Reduced padding */
+  background-color: #f1f1f1;
+  color: #333;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.google-btn:hover {
+  background-color: #e2e2e2;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+/* Links */
+.signup-box p {
+  color: #000000;
+  font-size: 0.9rem;
+}
+
+.signup-box a {
+  color: #000000 !important;
+}
+
+/* Dark theme overrides for the login/signup box */
+.dark-theme-login .signup-box,
+.dark-theme-signup .signup-box {
+  background-color: #f7f7f7;
+  color: #e2e8f0;
+}
+
+.dark-theme-login .signup-box h2,
+.dark-theme-signup .signup-box h2 {
+  color: #020202;
+}
+
+.dark-theme-login .signup-form input,
+.dark-theme-signup .signup-form input {
+  background-color: #000000;
+  border-color: #000000;
+  color: #e2e8f0;
+}
+
+.dark-theme-login .signup-form input:focus,
+.dark-theme-signup .signup-form input:focus {
+  border-color: #070707;
+  box-shadow: 0 0 8px rgba(5, 5, 5, 0.4);
+}
+
+.dark-theme-login .signup-form button[type="submit"],
+.dark-theme-signup .signup-form button[type="submit"] {
+  background-color: #0c0c0c;
+}
+
+.dark-theme-login .signup-form button[type="submit"]:hover,
+.dark-theme-signup .signup-form button[type="submit"]:hover {
+  background-color: #000000;
+}
+
+.dark-theme-login .google-btn,
+.dark-theme-signup .google-btn {
+  background-color: #010101;
+  color: #e2e8f0;
+  border-color: #4a5568;
+}
+
+.dark-theme-login .google-btn:hover,
+.dark-theme-signup .google-btn:hover {
+  background-color: #040404;
+}
+
+.dark-theme-login .divider,
+.dark-theme-signup .divider {
+  color: #090a0a;
+}
+
+.dark-theme-login .divider::before,
+.dark-theme-signup .divider::before,
+.dark-theme-login .divider::after,
+.dark-theme-signup .divider::after {
+  background-color: #000000;
+}
+
+.dark-theme-login .signup-box a,
+.dark-theme-signup .signup-box a {
+  color: #0a0a0a !important;
 }
 
 /* Responsive Design */
@@ -137,42 +300,7 @@
   .split-content {
     flex-direction: column;
     gap: 2rem;
-   
-
+    min-height: auto;
   }
-
-  .hero-box, .signup-box {
-    max-width: 100%;
-    text-align: center;
-  }
-
-  .hero-box button {
-    width: 100%;
-  }
-
-  
 }
 
-@media screen and (min-width:340px ) and (max-width:380px) 
- { .hero-box{
- margin-top:200px;
-}
-}
-
-@media screen and (min-width:320px ) and (max-width:339px)
- { .hero-box{
- margin-top:400px;
-}
-}
-@media screen and (min-width:390px ) and (max-width:420px)
- { .hero-box{
- margin-top:50px;
-}
-}
-
-.success-message {
-  color: #4caf50; /* green */
-  margin-top: 10px;
-  font-weight: bold;
-  text-align: center;
-}

--- a/src/pages/HomeSplit.jsx
+++ b/src/pages/HomeSplit.jsx
@@ -2,10 +2,12 @@ import React, { useRef, useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import { useTheme } from '../context/ThemeContext'; // Import the useTheme hook
 import "./HomeSplit.css";
 import HeroSection from "../Components/Hero";
 
 export default function HomeSplit({ setIsLoggedIn }) {
+  const { theme } = useTheme();
   const nameInputRef = useRef(null);
   const navigate = useNavigate();
 
@@ -13,13 +15,12 @@ export default function HomeSplit({ setIsLoggedIn }) {
   const [showPassword, setShowPassword] = useState(false);
 
   const handleStartPlanningClick = () => {
-  if (isSignedIn) {
-    navigate("/plan");
-  } else {
-    toast.error("Please sign up first!");
-  }
-};
-
+    if (isSignedIn) {
+      navigate("/plan");
+    } else {
+      toast.error("Please sign up first!");
+    }
+  };
 
   const handleSignup = (e) => {
     e.preventDefault();
@@ -29,9 +30,10 @@ export default function HomeSplit({ setIsLoggedIn }) {
   };
 
   return (
-    <div className="page-background">
+    // Conditionally add a 'dark-theme-home' class based on the current theme
+    <div className={`page-background ${theme === 'dark' ? 'dark-theme-home' : ''}`}>
       <div className="overlay ">
-        <div className="flex flex-col  justify-center lg:flex-row  items-center split-content">
+        <div className="flex flex-col justify-center lg:flex-row items-center split-content">
           {/* Hero Section */}
           <HeroSection />
           {/* Signup Section */}

--- a/src/pages/PlanTrip.jsx
+++ b/src/pages/PlanTrip.jsx
@@ -5,9 +5,11 @@ import Refresh from "../Components/Refresh";
 import "../index.css";
 import "../Components/Navbar.css";
 import { FaPlaneDeparture, FaGlobeAsia, FaSortAmountDownAlt } from "react-icons/fa";
-import "./PlanTrip.css"; 
+import "./PlanTrip.css";
+import { useTheme } from '../context/ThemeContext'; // Import the useTheme hook
 
 export default function PlanTrip({ searchQuery }) {
+  const { theme } = useTheme(); // Use the custom hook to get the current theme
   const [tour, setTour] = useState(data);
   const [selectedRegion, setSelectedRegion] = useState("All");
   const [sortBy, setSortBy] = useState("default");
@@ -89,7 +91,8 @@ export default function PlanTrip({ searchQuery }) {
   }
 
   return (
-    <div className="plan-trip-container">
+    // Add a conditional class for dark mode to the main container
+    <div className={`plan-trip-container ${theme === 'dark' ? 'dark-theme-plan' : ''}`}>
       <div className="title-section">
         <h2 className="trip-title">
           <FaPlaneDeparture className="trip-icon" /> Your Trip Planner

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,59 +1,94 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { Link } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { ToastContainer, toast } from "react-toastify";
-import { Loader2 } from "lucide-react";  // Import the loading spinner icon
+import { Loader2 } from "lucide-react";
 import "react-toastify/dist/ReactToastify.css";
 import HeroSection from "../Components/Hero";
+import { useTheme } from '../context/ThemeContext';
+import "./HomeSplit.css";
 
+// --- Firebase Imports ---
+import { auth } from "../firebase"; // Make sure the path to firebase.js is correct
+import { GoogleAuthProvider, signInWithPopup, createUserWithEmailAndPassword } from "firebase/auth";
 
 export default function Signup({ setIsLoggedIn }) {
+  const { theme } = useTheme();
   const navigate = useNavigate();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
-  const [isLoggedInLocal, setIsLoggedInLocal] = useState(false);
-  const [isLoading, setIsLoading] = useState(false); // Track loading state
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleSignup = (e) => {
     e.preventDefault();
-
-    // Basic validation
-    if (name && email && password) {
-      setIsLoading(true); // Set loading state to true when signup is initiated
-
-      toast.success("Signup successful!");
-      
-      setTimeout(() => {
-        setIsLoggedIn(true);  // Set login state to true
-        setIsLoggedInLocal(true);  // Track login state in component state
-        setIsLoading(false);  // Reset loading state
-        navigate("/plan");  // Redirect after showing the toast
-      }, 1500); // Wait for 1.5 seconds before redirecting
-
-    } else {
+    if (!name || !email || !password) {
       toast.error("Please fill all fields");
+      return;
+    }
+    setIsLoading(true);
+    createUserWithEmailAndPassword(auth, email, password)
+      .then((userCredential) => {
+        setIsLoading(false);
+        setIsLoggedIn(true);
+        toast.success("Signed up successfully!");
+        navigate("/plan");
+      })
+      .catch((error) => {
+        setIsLoading(false);
+        if (error.code === 'auth/email-already-in-use') {
+          toast.error("This email address is already in use.");
+        } else if (error.code === 'auth/weak-password') {
+          toast.error("Password should be at least 6 characters.");
+        } else {
+          toast.error("Failed to create an account.");
+        }
+        console.error("Error during signup:", error);
+      });
+  };
+
+  const handleGoogleSignIn = async () => {
+    const provider = new GoogleAuthProvider();
+    provider.setCustomParameters({ prompt: 'select_account' });
+    
+    try {
+      await signInWithPopup(auth, provider);
+      setIsLoggedIn(true);
+      toast.success("Signed up with Google successfully!");
+      navigate("/plan");
+    } catch (error) {
+      console.error("Error during Google sign-in:", error);
+      toast.error("Failed to sign up with Google.");
     }
   };
 
+  const handleForgotPassword = () => {
+    if (!email) {
+      toast.error("Please enter your email address first.");
+      return;
+    }
+    // Implement password reset logic here, if needed. For now, it will show a toast.
+    toast.info("Password reset link sent to your email!");
+  };
+
   return (
-    <div className="page-background">
+    <div className={`page-background ${theme === 'dark' ? 'dark-theme-signup' : ''}`}>
       <div className="overlay">
         <div className="split-content">
           {/* Hero Section */}
-         <HeroSection/>
+          <div className="hero-section-wrapper">
+            <HeroSection/>
+          </div>
           {/* Signup Section */}
           <div className="signup-box">
-            <form className="signup-form space-y-4" onSubmit={handleSignup}>
-              <h2 className="text-3xl font-bold">Sign Up</h2>
+            <form className="signup-form" onSubmit={handleSignup}>
+              <h2>Sign Up</h2>
 
               <input
                 type="text"
                 placeholder="Name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="w-full p-3 rounded-md border border-gray-300"
                 required
               />
 
@@ -62,7 +97,6 @@ export default function Signup({ setIsLoggedIn }) {
                 placeholder="Email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="w-full p-3 rounded-md border border-gray-300"
                 required
               />
 
@@ -71,23 +105,26 @@ export default function Signup({ setIsLoggedIn }) {
                 placeholder="Password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="w-full p-3 rounded-md border border-gray-300"
                 required
               />
-
-              <label className="flex items-center space-x-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={showPassword}
-                  onChange={() => setShowPassword(!showPassword)}
-                  className="form-checkbox h-4 w-4"
-                />
-                <span>Show Password</span>
-              </label>
+              
+              <div className="password-options">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={showPassword}
+                    onChange={() => setShowPassword(!showPassword)}
+                  />
+                  Show Password
+                </label>
+                {/* The signup page doesn't usually have a forgot password link, but if you want it, this is how you'd add it */}
+                {/* <span className="forgot-password" onClick={handleForgotPassword}>
+                  Forgot Password?
+                </span> */}
+              </div>
 
               <button 
                 type="submit" 
-                className="w-full p-3 mt-4 bg-blue-500 text-white rounded-md focus:outline-none disabled:bg-gray-300"
                 disabled={isLoading}
               >
                 {isLoading ? (
@@ -97,6 +134,15 @@ export default function Signup({ setIsLoggedIn }) {
                 )}
               </button>
 
+              <div className="divider">OR</div>
+
+              <button type="button" className="google-btn" onClick={handleGoogleSignIn}>
+                <svg viewBox="0 0 48 48" width="24px" height="24px">
+                  <path fill="#FFC107" d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12s5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24s8.955,20,20,20s20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"></path><path fill="#FF3D00" d="M6.306,14.691l6.571,4.819C14.655,15.108,18.961,12,24,12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"></path><path fill="#4CAF50" d="M24,44c5.166,0,9.86-1.977,13.409-5.192l-6.19-5.238C29.211,35.091,26.715,36,24,36c-5.222,0-9.61-3.317-11.28-7.946l-6.522,5.025C9.505,39.556,16.227,44,24,44z"></path><path fill="#1976D2" d="M43.611,20.083H42V20H24v8h11.303c-0.792,2.237-2.231,4.166-4.087,5.571l6.19,5.238C39.999,35.596,44,30.033,44,24C44,22.659,43.862,21.35,43.611,20.083z"></path>
+                </svg>
+                Continue with Google
+              </button>
+
               <p className="text-center mt-4">
                 Already have an Account?{" "}
                 <Link to="/login" className="text-blue-500 hover:underline">
@@ -104,15 +150,10 @@ export default function Signup({ setIsLoggedIn }) {
                 </Link>
               </p>
             </form>
-
-            {isLoggedInLocal && (
-              <p className="success-message text-center text-green-600">Logged in successfully</p>
-            )}
           </div>
         </div>
       </div>
 
-      {/* Toast Notification Container */}
       <ToastContainer
         position="bottom-left"
         autoClose={3000}
@@ -127,3 +168,6 @@ export default function Signup({ setIsLoggedIn }) {
     </div>
   );
 }
+
+
+

--- a/src/pages/TripRecommender.jsx
+++ b/src/pages/TripRecommender.jsx
@@ -1,8 +1,11 @@
 import React, { useState } from "react";
 import { FaGlobeAsia, FaSearch, FaCompass } from "react-icons/fa";
 import data from "../data";
+import { useTheme } from "../context/ThemeContext";
+import "../Components/tripRecommender.css";
 
 export default function TripRecommender() {
+  const { theme } = useTheme();
   const [selectedMood, setSelectedMood] = useState("");
   const [selectedPurpose, setSelectedPurpose] = useState("");
   const [recommendations, setRecommendations] = useState([]);
@@ -21,24 +24,21 @@ export default function TripRecommender() {
   };
 
   return (
-    <div className="max-w-7xl mx-auto px-4 py-16">
-      <h2 className="text-4xl font-extrabold text-center mb-2 text-gray-900 flex justify-center items-center gap-2">
-        <FaGlobeAsia className="text-green-600 text-4xl" />
-        Trip Recommender
-      </h2>
-      <p className="text-center text-gray-500 mb-10 text-lg">
-        Discover your next destination based on your mood and travel goals ✨
-      </p>
+    <div className={`trip-recommender-container ${theme === 'dark' ? 'dark-theme-recommender' : ''}`}>
+      <div className="trip-recommender-header">
+        <h2 className="trip-recommender-title">
+          <FaGlobeAsia className="trip-recommender-icon" />
+          Trip Recommender
+        </h2>
+        <p className="trip-recommender-subtitle">
+          Discover your next destination based on your mood and travel goals ✨
+        </p>
+      </div>
 
-      {/* Filters */}
-      <div className="flex flex-wrap justify-center gap-6 mb-14">
-        <div className="flex flex-col">
-          <label className="mb-2 text-gray-800 font-semibold text-sm tracking-wide">Mood</label>
-          <select
-            value={selectedMood}
-            onChange={(e) => setSelectedMood(e.target.value)}
-            className="rounded-xl border border-gray-300 px-5 py-3 shadow-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 hover:shadow-md transition-all duration-200"
-          >
+      <div className="filters">
+        <div className="filter-group">
+          <label>Mood</label>
+          <select value={selectedMood} onChange={(e) => setSelectedMood(e.target.value)}>
             <option value="">Select Mood</option>
             {moods.map((mood, i) => (
               <option key={i} value={mood}>
@@ -48,13 +48,9 @@ export default function TripRecommender() {
           </select>
         </div>
 
-        <div className="flex flex-col">
-          <label className="mb-2 text-gray-800 font-semibold text-sm tracking-wide">Purpose</label>
-          <select
-            value={selectedPurpose}
-            onChange={(e) => setSelectedPurpose(e.target.value)}
-            className="rounded-xl border border-gray-300 px-5 py-3 shadow-sm bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 hover:shadow-md transition-all duration-200"
-          >
+        <div className="filter-group">
+          <label>Purpose</label>
+          <select value={selectedPurpose} onChange={(e) => setSelectedPurpose(e.target.value)}>
             <option value="">Select Purpose</option>
             {purposes.map((purpose, i) => (
               <option key={i} value={purpose}>
@@ -64,57 +60,34 @@ export default function TripRecommender() {
           </select>
         </div>
 
-        <button
-          onClick={handleFilter}
-          className="self-end flex items-center gap-2 bg-gradient-to-r from-green-500 to-green-600 text-white px-6 py-3 rounded-xl font-semibold hover:from-green-600 hover:to-green-700 focus:ring-2 focus:ring-green-400 shadow-md hover:shadow-lg transition-all duration-200"
-        >
+        <button onClick={handleFilter} className="filter-button">
           <FaSearch />
           Find Trips
         </button>
       </div>
 
-      {/* Results */}
-      <div className="grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="results">
         {recommendations.length > 0 ? (
           recommendations.map((place) => (
-            <div
-              key={place.id}
-              className="bg-white rounded-2xl shadow-md hover:shadow-xl hover:scale-[1.01] transition-all duration-300 overflow-hidden"
-            >
-              <img
-                src={place.image}
-                alt={place.name}
-                className="w-full h-48 object-cover"
-              />
-              <div className="p-5">
-                <div className="flex items-center justify-between mb-3">
-                  <h4 className="text-green-600 font-semibold text-lg">
-                    ₹ {place.price.toLocaleString()}
-                  </h4>
-                  <h4 className="font-semibold text-gray-800 text-right text-sm leading-tight">
+            <div key={place.id} className="place-card">
+              <img src={place.image} alt={place.name} className="cityImage" />
+              <div className="tourInfo">
+                <div className="tourHeader">
+                  <h4 className="tourPrice">₹ {place.price.toLocaleString()}</h4>
+                  <h4 className="tourCityName">
                     {place.emoji} {place.name}
-                    <span className="text-gray-400 text-xs ml-1 block">
-                      {place.region}
-                    </span>
+                    <span className="region">({place.region})</span>
                   </h4>
                 </div>
-                <p className="text-gray-600 text-sm mb-4 leading-relaxed">
-                  {place.info}
-                </p>
-                <div className="flex flex-wrap gap-2 text-xs font-medium">
+                <p className="tourDetails">{place.info}</p>
+                <div className="tags">
                   {place.moodTags.map((tag, i) => (
-                    <span
-                      key={i}
-                      className="bg-blue-100 text-blue-600 px-3 py-1 rounded-full"
-                    >
+                    <span key={i} className="tag tag-mood">
                       {tag}
                     </span>
                   ))}
                   {place.purposeTags.map((tag, i) => (
-                    <span
-                      key={i}
-                      className="bg-green-100 text-green-600 px-3 py-1 rounded-full"
-                    >
+                    <span key={i} className="tag tag-purpose">
                       {tag}
                     </span>
                   ))}
@@ -123,8 +96,8 @@ export default function TripRecommender() {
             </div>
           ))
         ) : (
-          <div className="col-span-full text-center text-gray-500 text-base">
-            <FaCompass className="text-5xl text-gray-400 mb-4 mx-auto" />
+          <div className="no-recommendations">
+            <FaCompass className="compass-icon" />
             <p>No recommendations yet. Select a mood and purpose to begin.</p>
           </div>
         )}
@@ -132,3 +105,4 @@ export default function TripRecommender() {
     </div>
   );
 }
+

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -1,43 +1,91 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Link } from "react-router-dom";
 import "./HomeSplit.css";
 import { ToastContainer, toast } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
+import "react-toastify/dist/ReactToastify.css"; // Corrected import path
 import HeroSection from "../Components/Hero";
+import { Loader2 } from "lucide-react";
+import { useTheme } from '../context/ThemeContext';
+
+// --- Firebase Imports ---
+import { auth } from "../firebase";
+import {
+  GoogleAuthProvider,
+  signInWithPopup,
+  sendPasswordResetEmail,
+  signInWithEmailAndPassword
+} from "firebase/auth";
 
 export default function Login({ setIsLoggedIn }) {
+  const { theme } = useTheme();
   const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
-  const [isLoggedInLocal, setIsLoggedInLocal] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleLogin = (e) => {
     e.preventDefault();
-
-    if (email && password) {
-      setIsLoggedIn(true);
-      setIsLoggedInLocal(true);
-      toast.success("Login successful!");
-      navigate("/plan");
-    } else {
+    if (!email || !password) {
       toast.error("Please enter email and password");
+      return;
+    }
+    setIsLoading(true);
+    signInWithEmailAndPassword(auth, email, password)
+      .then((userCredential) => {
+        setIsLoading(false);
+        setIsLoggedIn(true);
+        toast.success("Login successful!");
+        navigate("/plan");
+      })
+      .catch((error) => {
+        setIsLoading(false);
+        toast.error("Incorrect email or password.");
+        console.error("Error during login:", error);
+      });
+  };
+
+  const handleGoogleSignIn = async () => {
+    const provider = new GoogleAuthProvider();
+    provider.setCustomParameters({ prompt: 'select_account' });
+
+    try {
+      await signInWithPopup(auth, provider);
+      setIsLoggedIn(true);
+      toast.success("Logged in with Google successfully!");
+      navigate("/plan");
+    } catch (error) {
+      console.error("Error during Google sign-in:", error);
+      toast.error("Failed to sign in with Google.");
     }
   };
 
+  const handleForgotPassword = () => {
+    if (!email) {
+      toast.error("Please enter your email address first.");
+      return;
+    }
+    sendPasswordResetEmail(auth, email)
+      .then(() => {
+        toast.info("Password reset email sent! Please check your inbox.");
+      })
+      .catch((error) => {
+        console.error("Error sending password reset email:", error);
+        toast.error("Failed to send password reset email.");
+      });
+  };
+
   return (
-    <div className="page-background">
+    <div className={`page-background ${theme === 'dark' ? 'dark-theme-login' : ''}`}>
       <div className="overlay">
         <div className="split-content">
-          {/* Hero Section */}
-          <HeroSection/>
-
-          {/* Login Section */}
+          <div className="hero-section-wrapper">
+            <HeroSection/>
+          </div>
           <div className="signup-box">
             <form className="signup-form" onSubmit={handleLogin}>
               <h2>Login</h2>
-
               <input
                 type="email"
                 placeholder="Email"
@@ -45,7 +93,6 @@ export default function Login({ setIsLoggedIn }) {
                 onChange={(e) => setEmail(e.target.value)}
                 required
               />
-
               <input
                 type={showPassword ? "text" : "password"}
                 placeholder="Password"
@@ -53,19 +100,33 @@ export default function Login({ setIsLoggedIn }) {
                 onChange={(e) => setPassword(e.target.value)}
                 required
               />
-
-              <label style={{ display: "block", marginTop: "8px" }}>
-                <input
-                  type="checkbox"
-                  checked={showPassword}
-                  onChange={() => setShowPassword(!showPassword)}
-                  style={{ marginRight: "5px" }}
-                />
-                Show Password
-              </label>
-
-              <button type="submit">Login</button>
-
+              <div className="password-options">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={showPassword}
+                    onChange={() => setShowPassword(!showPassword)}
+                  />
+                  Show Password
+                </label>
+                <span className="forgot-password" onClick={handleForgotPassword}>
+                  Forgot Password?
+                </span>
+              </div>
+              <button type="submit" disabled={isLoading}>
+                {isLoading ? (
+                  <Loader2 size={18} className="animate-spin mx-auto" />
+                ) : (
+                  "Login"
+                )}
+              </button>
+              <div className="divider">OR</div>
+              <button type="button" className="google-btn" onClick={handleGoogleSignIn}>
+                <svg viewBox="0 0 48 48" width="24px" height="24px">
+                  <path fill="#FFC107" d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12s5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24s8.955,20,20,20s20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"></path><path fill="#FF3D00" d="M6.306,14.691l6.571,4.819C14.655,15.108,18.961,12,24,12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"></path><path fill="#4CAF50" d="M24,44c5.166,0,9.86-1.977,13.409-5.192l-6.19-5.238C29.211,35.091,26.715,36,24,36c-5.222,0-9.61-3.317-11.28-7.946l-6.522,5.025C9.505,39.556,16.227,44,24,44z"></path><path fill="#1976D2" d="M43.611,20.083H42V20H24v8h11.303c-0.792,2.237-2.231,4.166-4.087,5.571l6.19,5.238C39.999,35.596,44,30.033,44,24C44,22.659,43.862,21.35,43.611,20.083z"></path>
+                </svg>
+                Continue with Google
+              </button>
               <p style={{ textAlign: "center" }}>
                 Don't have an Account?{" "}
                 <Link to="/" style={{ color: "blue" }}>
@@ -73,9 +134,6 @@ export default function Login({ setIsLoggedIn }) {
                 </Link>
               </p>
             </form>
-            {isLoggedInLocal && (
-              <p className="success-message">LoggedIn successfully</p>
-            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
This pull request adds a dark mode toggle to the website's navigation bar, allowing users to switch between light and dark themes. The user's preference is saved in local storage, so the theme persists across sessions.

I have updated the following files to be dark-mode compatible:
<img width="1888" height="862" alt="Screenshot 2025-08-10 073146" src="https://github.com/user-attachments/assets/0ddd0191-7b84-44d9-909f-beba72a2674c" />
<img width="1888" height="772" alt="Screenshot 2025-08-10 073202" src="https://github.com/user-attachments/assets/12ec2bd6-d728-4dea-bb77-2aa1c11d64ca" />
<img width="1895" height="878" alt="Screenshot 2025-08-10 073222" src="https://github.com/user-attachments/assets/ed3fc8a4-97b9-41ab-b4d2-12cf5ff4e24d" />
<img width="1900" height="875" alt="Screenshot 2025-08-10 073234" src="https://github.com/user-attachments/assets/08233869-cf9e-448e-b59a-2d9b5badbc47" />
<img width="1901" height="850" alt="Screenshot 2025-08-10 073305" src="https://github.com/user-attachments/assets/3a80cf86-31d2-4bb8-affc-89d1fb525f8e" />
<img width="1885" height="847" alt="Screenshot 2025-08-10 073329" src="https://github.com/user-attachments/assets/7b737b70-f9c1-4e18-95f5-d1620e09a9ef" />
<img width="1891" height="768" alt="Screenshot 2025-08-10 073347" src="https://github.com/user-attachments/assets/643fced3-5b26-49e9-baf2-a6537f99c0aa" />
<img width="1919" height="867" alt="Screenshot 2025-08-10 073356" src="https://github.com/user-attachments/assets/39e6ab88-6948-4815-ad4e-652981188629" />
[instructions.txt](https://github.com/user-attachments/files/21703154/instructions.txt)

src/context/ThemeContext.js
src/App.js
src/Components/Navbar.jsx
src/pages/login.jsx
src/pages/Signup.jsx
src/pages/HomeSplit.css
src/index.css
Closes #110