### PR TITLE
feat: update frontend to use Render backend URL

### DIFF
--- a/GEMINI_SETUP.md
+++ b/GEMINI_SETUP.md
@@ -36,8 +36,9 @@ node server.js
 
 ### 4. Test the Setup
 
+
 You can test if the API is working by visiting:
-- Health check: `http://localhost:5000/api/health`
+- Health check: `https://trip-planner-backend-bw79.onrender.com/api/health`
 - The chatbot should now work with Gemini responses
 
 ## Model Features

--- a/src/pages/Chatbot.jsx
+++ b/src/pages/Chatbot.jsx
@@ -19,7 +19,7 @@ function ChatBot() {
     setIsTyping(true);
 
     try {
-      const res = await fetch("http://localhost:5000/api/chat", {
+  const res = await fetch("https://trip-planner-backend-bw79.onrender.com/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message }),


### PR DESCRIPTION
Closes #40 - Updated Chatbot.jsx to use https://trip-planner-backend-bw79.onrender.com/api/chat
- Now fully integrated with deployed backend API