### PR TITLE
Feature/improve ux loading skeletons

### DIFF
--- a/src/Components/SkeletonCard.jsx
+++ b/src/Components/SkeletonCard.jsx
@@ -1,0 +1,31 @@
+
+import React from "react";
+
+/**
+ * SkeletonCard Component
+ * Reusable loading placeholder with shimmer effect.
+ * Usage: Show while data is being fetched.
+ */
+export default function SkeletonCard({ height = "auto" }) {
+  return (
+    <div className="animate-pulse bg-white dark:bg-gray-800 rounded-2xl shadow-md overflow-hidden"
+    style={{ height }}>
+      {/* Image Placeholder */}
+      <div className="w-full h-48 bg-gray-300 dark:bg-gray-700"></div>
+
+      {/* Text placeholders */}
+      <div className="p-5 space-y-3">
+        <div className="h-4 bg-gray-300 dark:bg-gray-700 rounded w-1/2"></div>
+        <div className="h-3 bg-gray-300 dark:bg-gray-700 rounded w-2/3"></div>
+        <div className="h-3 bg-gray-300 dark:bg-gray-700 rounded w-1/3"></div>
+
+        {/* Tags placeholder */}
+        <div className="flex gap-2">
+          <div className="h-5 w-12 bg-gray-300 dark:bg-gray-700 rounded-full"></div>
+          <div className="h-5 w-16 bg-gray-300 dark:bg-gray-700 rounded-full"></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/DestinationPage.jsx
+++ b/src/pages/DestinationPage.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams, Link } from "react-router-dom";
 import data from '../data';
 import { FaMapMarkerAlt, FaRupeeSign, FaRegCalendarAlt, FaArrowLeft, FaTag } from 'react-icons/fa';
 import { useInterested } from '../contexts/InterestedContext';
 import { toast } from 'react-toastify';
-
+import SkeletonCard from "../Components/SkeletonCard";
 const Tag = ({ text, colorClass }) => (
   <span className={`text-xs font-semibold inline-block py-1 px-2 uppercase rounded-full last:mr-0 mr-1 ${colorClass}`}>
     {text}
@@ -15,14 +15,31 @@ export default function DestinationPage() {
   const { id } = useParams();
   const { addToInterested } = useInterested();
 
-  // Find the destination from the main data source
-  const destination = data.find(d => d.name.toLowerCase() === id.toLowerCase());
+  //  Local state to handle loading
+  const [loading, setLoading] = useState(true);
+  const [destination, setDestination] = useState(null);
 
+  // Simulate data fetch with useEffect
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const found = data.find(d => d.name.toLowerCase() === id.toLowerCase());// Find the destination from the main data source
+      setDestination(found || null);
+      setLoading(false);
+    }, 1000); // simulate 1s delay
+    return () => clearTimeout(timer);
+  }, [id]);
   const handleAddToInterested = () => {
     addToInterested(destination);
     toast.success(`${destination.name} added to your interested list!`);
   };
-
+  // Show Skeleton while loading
+  if (loading) {
+    return (
+      <div className="max-w-7xl mx-auto p-6">
+        <SkeletonCard /> {/* Full page skeleton */}
+      </div>
+    );
+  }
   if (!destination) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[calc(100vh-13rem)] text-center px-4">
@@ -79,7 +96,7 @@ export default function DestinationPage() {
           <div className="lg:col-span-2 bg-white dark:bg-gray-800 p-8 rounded-2xl shadow-lg">
             <h2 className="text-2xl font-bold mb-4 text-gray-800 dark:text-white">About this destination</h2>
             <p className="text-gray-600 dark:text-gray-400 mb-6 leading-relaxed">{destination.info}</p>
-            
+
             <div className="flex items-center justify-between mb-6 p-4 bg-gray-100 dark:bg-gray-700 rounded-xl">
               <span className="flex items-center gap-2 text-green-600 dark:text-green-400 font-bold text-xl"><FaRupeeSign /> {destination.price.toLocaleString('en-IN')}</span>
               <span className="flex items-center gap-2 text-gray-500 dark:text-gray-400 text-md"><FaRegCalendarAlt /> {destination.duration}</span>

--- a/src/pages/PlanTrip.jsx
+++ b/src/pages/PlanTrip.jsx
@@ -5,6 +5,8 @@ import Tours from "../Components/Tours";
 import { FaMapMarkedAlt, FaSearch, FaTimesCircle } from "react-icons/fa";
 import "../index.css";
 import "../Components/Navbar.css";
+//  Import SkeletonCard for loading state
+import SkeletonCard from "../Components/SkeletonCard";
 
 export default function PlanTrip({ searchQuery = "" }) {
   const [tour, setTour] = useState(data);
@@ -15,6 +17,8 @@ export default function PlanTrip({ searchQuery = "" }) {
   const [showRegionDropdown, setShowRegionDropdown] = useState(false);
   const [showSortDropdown, setShowSortDropdown] = useState(false);
 
+ //  Added loading state
+  const [isLoading, setIsLoading] = useState(true);
   const regions = [
     "All",
     ...new Set(
@@ -89,6 +93,15 @@ export default function PlanTrip({ searchQuery = "" }) {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
+
+  //  Simulate loading effect when component mounts
+  useEffect(() => {
+    setIsLoading(true);
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, 1000); // fake 1 second loading
+    return () => clearTimeout(timer);
+  }, [selectedCountry, selectedRegion, sortBy, localSearchQuery]);
 
   return (
     <div className="px-4 py-10 md:px-16 lg:px-24">
@@ -222,9 +235,18 @@ export default function PlanTrip({ searchQuery = "" }) {
 </div>
 
        
+       {/* Search, Filter and Sort Controls */}
+      {/* ... (unchanged filter UI code) ... */}
 
       {/* Tours List with Improved Card Layout */}
-      {sortedAndFilteredTours.length > 0 ? (
+      {isLoading ? (
+        // ✅ Show Skeletons while loading
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 md:gap-8">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <SkeletonCard key={index} />
+          ))}
+        </div>
+      ) : sortedAndFilteredTours.length > 0 ? (
         // <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 md:gap-8">
           <Tours
             tours={sortedAndFilteredTours}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react'; 
 import { useNavigate } from 'react-router-dom';
 import { signOut } from "firebase/auth";
 import { auth } from "../firebase"; 
 import { toast } from "react-toastify";
 import { FaUser, FaSignOutAlt, FaEdit, FaSave, FaTimes } from 'react-icons/fa';
-
+import SkeletonCard from "../Components/SkeletonCard";
 const Profile = () => {
   const navigate = useNavigate();
   const [isEditing, setIsEditing] = useState(false);
@@ -16,7 +16,13 @@ const Profile = () => {
     joinDate: 'January 2024'
   });
   const [editInfo, setEditInfo] = useState({ ...userInfo });
-
+   
+  const [isLoading, setIsLoading] = useState(true);//  loading state for skeleton
+ //  Fake delay to simulate API call or Firebase fetch
+  useEffect(() => {
+    const timer = setTimeout(() => setIsLoading(false), 1500);
+    return () => clearTimeout(timer);
+  }, []);
 const handleLogout = () => {
   signOut(auth)
     .then(() => {
@@ -52,6 +58,17 @@ const handleLogout = () => {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-300">
       <div className="container mx-auto px-4 py-8 max-w-4xl">
+        
+        {/*  Show skeleton loader while profile data is "loading" */}
+        {isLoading ? (
+          <div className="space-y-6">
+            <SkeletonCard height="150px" /> {/* Profile card skeleton */}
+            <SkeletonCard height="120px" /> {/* Stats section skeleton */}
+            <SkeletonCard height="200px" /> {/* Recent activity skeleton */}
+            <SkeletonCard height="100px" /> {/* Account actions skeleton */}
+          </div>
+        ) : (   
+          <>
         {/* Profile Header */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-8 mb-8">
           <div className="flex flex-col md:flex-row items-center md:items-start gap-6">
@@ -186,6 +203,8 @@ const handleLogout = () => {
             <FaSignOutAlt /> Logout
           </button>
         </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/pages/TripRecommender.jsx
+++ b/src/pages/TripRecommender.jsx
@@ -2,13 +2,16 @@ import React, { useState,useEffect } from "react";
 import { FaGlobeAsia, FaSearch, FaCompass } from "react-icons/fa";
 import { useTheme } from '../contexts/ThemeContext';
 import data from "../data";
-
+import SkeletonCard from "../Components/SkeletonCard"; 
 export default function TripRecommender() {
   const { theme } = useTheme();
   const [selectedMood, setSelectedMood] = useState("");
   const [selectedPurpose, setSelectedPurpose] = useState("");
   const [selectedTheme, setSelectedTheme] = useState("");
   const [recommendations, setRecommendations] = useState([]);
+
+   // new-- state for loading indicator
+  const [loading, setLoading] = useState(true);
 
   const moods = [
     "Relaxing",
@@ -39,19 +42,33 @@ export default function TripRecommender() {
     "Spiritual Trip",
     "Educational Tour"
   ];
-
+// ------------------- UPDATED handleFilter -------------------
   const handleFilter = () => {
-    const filtered = data.filter((place) => {
-      const moodMatch = selectedMood ? place.moodTags.includes(selectedMood) : true;
-      const purposeMatch = selectedPurpose ? place.purposeTags.includes(selectedPurpose) : true;
-      const themeMatch = selectedTheme ? place.themeTags.includes(selectedTheme) : true;
-      return moodMatch && purposeMatch && themeMatch;
-    });
+    //  show skeletons
+    setLoading(true);
 
-    setRecommendations(filtered.slice(0, 6));
-  };
+    // simulate API delay (800ms)
+    setTimeout(() => {
+      const filtered = data.filter((place) => {
+        const moodMatch = selectedMood ? place.moodTags.includes(selectedMood) : true;
+        const purposeMatch = selectedPurpose ? place.purposeTags.includes(selectedPurpose) : true;
+        const themeMatch = selectedTheme ? place.themeTags.includes(selectedTheme) : true;
+        return moodMatch && purposeMatch && themeMatch;
+      });
+
+      setRecommendations(filtered.slice(0, 6));
+      //  stop skeletons
+      setLoading(false);
+    }, 800);
+  };// ------------------------------------------------------------
   useEffect(() => {
       window.scrollTo(0, 0);
+      // hide skeletons after 800ms on first load
+  const timer = setTimeout(() => {
+    setLoading(false);
+  }, 800);
+
+  return () => clearTimeout(timer); // cleanup
     }, []);
 
   return (
@@ -124,7 +141,10 @@ export default function TripRecommender() {
 
         {/* Results */}
         <div className="grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
-          {recommendations.length > 0 ? (
+            {loading ? (
+            // show skeletons when loading
+            Array(6).fill(0).map((_, i) => <SkeletonCard key={i} />)    ////
+          ) : recommendations.length > 0 ? (
             recommendations.map((place) => (
               <div
                 key={place.id}


### PR DESCRIPTION
Improve UX with Loading Skeletons for Profile, Destination, and Trip Recommendation Pages

This PR introduces loading skeletons across multiple pages to improve the overall user experience.
Previously, when fetching data or applying filters, the UI would either:
Appear empty for a few moments, or
Suddenly display results without visual feedback.
Now, skeleton placeholders provide a smooth transition, assuring users that content is loading.
- Changes Made
Added SkeletonCard.jsx → reusable skeleton component with shimmer effect.
Updated Profile.jsx → shows skeletons while user profile is loading.
Updated DestinationPage.jsx → skeletons for destination cards during data fetch.
Updated TripRecommendation.jsx → skeletons display while filtering trips before showing results.

 Screenshots (Before & After)
Before:
<img width="1920" height="1080" alt="Screenshot 2025-09-05 165533" src="https://github.com/user-attachments/assets/ab4e23c0-c99d-431e-927b-8cb52a6cca2f" />
After :
<img width="1902" height="931" alt="Screenshot 2025-09-05 164632" src="https://github.com/user-attachments/assets/7a8d7d4f-d870-4533-8668-847e88edaccf" />
<img width="1894" height="928" alt="Screenshot 2025-09-05 164608" src="https://github.com/user-attachments/assets/181c0af4-9722-4da4-a59e-ef7c05b0e104" />
<img width="1920" height="1080" alt="Screenshot 2025-09-05 164521" src="https://github.com/user-attachments/assets/173aa827-3043-4939-9c08-828acc3b2068" />


- How to Test
Navigate to Profile, Destination, or Trip Recommendation pages.
Trigger data fetch (e.g., apply filters in Trip Recommendation).
Confirm skeletons appear while content loads, then fade into actual results.

- Technical Notes
Skeletons are implemented with Tailwind CSS animate-pulse for shimmer effect.
No breaking changes to existing logic.
Code is reusable: any future page can adopt <SkeletonCard /> easily.

- Related Issue
Closes: Improve UX with Loading Skeletons