### PR TITLE
Real-time collaborative trip planning

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,19 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /sharedPlans/{planId} {
+      allow read: if true; // public read - change if needed
+      allow create: if request.auth != null || request.auth == null; // allow anonymous create
+      allow update, delete: if request.auth != null && (
+        request.auth.uid == resource.data.owner ||
+        (resource.data.allowedEditors is list && request.auth.uid in resource.data.allowedEditors)
+      );
+
+      // presence and locks subcollections only editable by authenticated users
+      match /{subCollection=**} {
+        allow read: if true;
+        allow write: if request.auth != null;
+      }
+    }
+  }
+}

--- a/src/Components/Card.jsx
+++ b/src/Components/Card.jsx
@@ -3,7 +3,7 @@ import { FaRupeeSign, FaMapMarkerAlt, FaRegCalendarAlt, FaRegThumbsDown } from '
 import { useTheme } from '../contexts/ThemeContext';
 import { useInterested } from '../contexts/InterestedContext';
 
-const Card = ({ tour, getRemoveId }) => {
+const Card = ({ tour, removeTour, lockItem, unlockItem, locked, presence }) => {
   const { theme } = useTheme();
   const { addToInterested } = useInterested(); 
   const [readmore, setReadmore] = useState(false);
@@ -76,7 +76,11 @@ const Card = ({ tour, getRemoveId }) => {
           >
             I'm Interested
           </button>
-          <button
+          <div className="flex items-center gap-2">
+            {locked ? (
+              <div className="text-xs text-yellow-600">Locked by {locked.lockedBy}</div>
+            ) : null}
+            <button
             className="flex items-center justify-center gap-2
          px-3 py-1.5
          rounded-md
@@ -86,11 +90,17 @@ const Card = ({ tour, getRemoveId }) => {
          hover:text-red-600 dark:hover:text-red-400
          border border-gray-200 dark:border-gray-600
          transition-all duration-200"
-            onClick={() => getRemoveId(tour.id)}
-            aria-label={`Remove ${tour.name} from Interested`}
+            onClick={() => {
+              // Remove from main plan (also propagates to Firestore when collaborating)
+              if (typeof removeTour === 'function') removeTour(tour.id);
+              // Also remove from interested list if the hook supports it
+              // ...existing code handles interested separately via context
+            }}
+            aria-label={`Remove ${tour.name} from Plan`}
           >
             <FaRegThumbsDown className="text-lg" /> Not Interested
           </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/Components/Tours.jsx
+++ b/src/Components/Tours.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Card from './Card.jsx';
 import { useInterested } from '../contexts/InterestedContext';
 
-const Tours = ({ tours, removeTour }) => {
+const Tours = ({ tours, removeTour, lockItem, unlockItem, locks, presence }) => {
   const { interestedTours, removeFromInterested } = useInterested();
 
   return (
@@ -13,7 +13,11 @@ const Tours = ({ tours, removeTour }) => {
           <Card
             key={tour.id}
             tour={tour}
-
+            removeTour={removeTour}
+            lockItem={lockItem}
+            unlockItem={unlockItem}
+            locked={locks?.[tour.id]}
+            presence={presence}
           />
         ))}
       </div>

--- a/src/lib/planModel.js
+++ b/src/lib/planModel.js
@@ -1,0 +1,14 @@
+// Helpers to convert tours array <-> map keyed by id
+export function arrayToMap(arr = []) {
+  const map = {};
+  arr.forEach((item) => {
+    if (item && item.id != null) map[item.id] = item;
+  });
+  return map;
+}
+
+export function mapToArray(map = {}) {
+  return Object.keys(map).map((k) => ({ ...map[k] }));
+}
+
+export default { arrayToMap, mapToArray };

--- a/src/lib/planModel.test.js
+++ b/src/lib/planModel.test.js
@@ -1,0 +1,14 @@
+import { arrayToMap, mapToArray } from './planModel';
+
+test('arrayToMap and mapToArray roundtrip', () => {
+  const arr = [
+    { id: 'a', name: 'A' },
+    { id: 'b', name: 'B' },
+  ];
+  const map = arrayToMap(arr);
+  expect(map.a.name).toBe('A');
+  expect(map.b.name).toBe('B');
+  const out = mapToArray(map);
+  expect(Array.isArray(out)).toBe(true);
+  expect(out.length).toBe(2);
+});


### PR DESCRIPTION
Added real-time collaborative trip planning backed by Firebase Firestore.
Switched the plan storage model to a per-item map (keyed by tour id) to reduce full-array overwrites.
Added anonymous auth, presence, simple per-item locks, metadata for plans, a plan browser UI, autosave, and manual save.
Wired existing UI actions (card removals) to the collaboration backend.
Added a small unit test for array/map conversions and an example [firestore.rules](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) file.
Files added

[planModel.js](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Helpers to convert between array-of-tours and a map keyed by tour [id](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
[arrayToMap(arr)](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — returns { [id]: tour }
[mapToArray(map)](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — returns array
Used to persist tours in Firestore as a map and convert snapshots back to arrays.
[planModel.test.js](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Unit test that verifies round-trip behavior of [arrayToMap](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [mapToArray](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
[firestore.rules](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Example Firestore security rules showing owner / allowedEditors checks and basic write/read rules for sharedPlans and its subcollections. (Example only — adapt before deploying.)
Files modified and what changed (purpose + important details)

[PlanTrip.jsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (major work)
Added imports for [auth](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and Firestore APIs plus [arrayToMap](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[mapToArray](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Anonymous auth: sign-in via Firebase Auth (auto-sign-in flow) and track [uid](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Plan model changes:
When creating/saving plans, tours are saved as a map keyed by id (uses [arrayToMap](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
When reading plans, tours maps converted back to arrays ([mapToArray](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
Metadata: plan document now includes [title](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [owner](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [allowedEditors](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) fields.
Presence: writes a presence doc in sharedPlans/{planId}/presence/{uid} and periodically updates [lastActive](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Locks: adds helpers to lock/unlock per-tour entries in sharedPlans/{planId}/locks/{tourId}.
Subscriptions:
main plan doc subscription (onSnapshot) now applies map -> array conversion and updates [planTitle](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
added subscriptions to [locks](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [presence](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) subcollections; stores this in local [locks](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [presence](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) state.
Autosave and manual save:
Debounced autosave (700ms) when collaborating.
Manual Save persists the full map immediately.
Plan browser:
[fetchPlansList()](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) reads available sharedPlans and lists them in UI so users can browse and join.
Clean-up: unsubscribes and presence removal on leave/unmount.
Error handling: console logging and status updates via [collabStatus](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
[Tours.jsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Now forwards [removeTour](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [lockItem](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [unlockItem](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [locks](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [presence](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) props to each [Card](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
This allows the cards to call the top-level removal handler (which syncs to Firestore) and display lock/presence info.
[Card.jsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Accepts new props: [removeTour](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [lockItem](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [unlockItem](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [locked](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [presence](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
"Not Interested" button now calls [removeTour(tour.id)](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so UI removals propagate to the shared plan.
Shows a simple lock indicator when a tour is locked (Locked by {locked.lockedBy}).
Keeps the "I'm Interested" behavior via the existing [InterestedContext](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
[PlanTrip.jsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (previous smaller edits)
The initial collaboration wiring, onSnapshot, simple create/join/save/leave, and save-on-remove logic were implemented earlier and extended to the enhanced model above.
Tests and diagnostics

Added [planModel.test.js](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Jest). Run npm test to run tests.
I ran code diagnostics; there were no syntax/compile errors reported after edits.
Data & structure notes

Firestore structure used by these changes:
sharedPlans/{planId} (doc) with fields: [title](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [owner](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [allowedEditors](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [tours](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (map), [createdAt](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [updatedAt](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
sharedPlans/{planId}/locks/{tourId} — per-item locks (doc contains [lockedBy](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [lockedAt](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
sharedPlans/{planId}/presence/{uid} — presence documents (doc contains [uid](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [lastActive](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Conversion helpers ensure the UI keeps using arrays while Firestore stores maps.
Security notes / production readiness

[firestore.rules](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is an example file included to show the intended owner/allowedEditors enforcement. It is NOT deployed automatically — you must review and deploy rules to your Firebase project.
Anonymous auth is implemented for quick demos. For production, replace or complement with Google/email auth and tighten Firestore rules accordingly.
How to test manually (quick steps)

Install deps (if not already): npm install
Start app: npm start (CRA will pick an available port if 3000 is busy)
In Plan Trip UI:
Create a shared plan, copy the id, open another browser tab/window, and join that id.
Remove a tour in one client — other client should reflect the change after the autosave delay.
Test lock/unlock (via UI hooks) to see lock indicator. Test presence by joining from a second client.
Follow-ups / recommended improvements

Switch to real auth (Google, email) and update rules to use request.auth.uid restrictions — required for production.
Improve locking semantics (lease expiration, forced release, or optimistic merge).
Add more unit and integration tests:
Mock Firestore for unit tests of subscription/merge logic.
Add e2e tests (Cypress) to simulate multi-client flow.
Add plan listing pagination and filtering, and UI to invite/allow editors.


