### PR TITLE
Fix: center plan your trip card on mobile view

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -134,9 +134,9 @@ const Home = () => {
             </div>
             <div
               onClick={() => navigate("/plan")}
-              className="cursor-pointer bg-white dark:bg-gray-800 p-14 rounded-lg shadow-md hover:scale-105 transform transition"
+              className="cursor-pointer bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:scale-105 transform transition"
             >
-              <h3 className="mt-2 text-xl font-semibold text-gray-800 dark:text-white mb-3">
+              <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-3">
                 Plan Your Trip
               </h3>
               <p className="text-gray-600 dark:text-gray-300">


### PR DESCRIPTION
### Description 
This PR resolves the alignment issue where the feature cards on the main page were not horizontally centered on mobile viewports, breaking the layout's symmetry.
The fix applies adjusting the padding of the text inside the card.
Closes #296

## Screenshot
<img width="300" height="500" alt="Screenshot 2025-09-28 004024" src="https://github.com/user-attachments/assets/ccfadf7f-738d-4e82-b256-e1cdffb881d3" />
