### PR TITLE
Login buttons on Hero Section of Homepage

### DIFF
--- a/src/Components/Navbar.jsx
+++ b/src/Components/Navbar.jsx
@@ -290,9 +290,15 @@ const Navbar = ({ isLoggedIn }) => {
                   {/* Login Button */}
                   <Link
                     to="/login"
-                    className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors duration-200 font-medium"
+                    className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-gray-100 hover:text-blue-700  transition-colors duration-200 font-medium"
                   >
                     Login
+                  </Link>
+                  <Link
+                    to="/signup"
+                    className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-gray-100 hover:text-blue-700  transition-colors duration-200 font-medium"
+                  >
+                    Signup
                   </Link>
                 </>
               )}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -76,7 +76,7 @@ const Home = () => {
                     Plan your next adventure, track expenses, and get AI-powered
                     recommendations. All in one place.
                 </p>
-                <div className="mt-8 space-x-4">
+                {/* <div className="mt-8 space-x-4">
                     <button
                         onClick={() => navigate("/login")}
                         className="px-6 py-3 bg-white text-blue-600 font-semibold rounded-lg shadow hover:bg-gray-200"
@@ -89,7 +89,7 @@ const Home = () => {
                     >
                         Signup
                     </button>
-                </div>
+                </div> */}
                 {/* Animated Plane Icon */}
             </section>
 


### PR DESCRIPTION
The Hero Section of the homepage is now not having the Login and Sign up buttons instead they are in the Navigation Bar so that these could be accessed from across all the pages.

Here, we can clearly see that the Issue got resolved,
<img width="1679" height="662" alt="image" src="https://github.com/user-attachments/assets/a58ecca4-1b65-4373-9946-3edf2b5aa721" />

Issue #352 got resolved.

I loved to work on this issue and looking to contribute more towards the project with rising more issues.