### PR TITLE
fixed issue:In Contact page the two boxes have contrast colours

### DIFF
--- a/src/pages/ContactUs.jsx
+++ b/src/pages/ContactUs.jsx
@@ -28,11 +28,11 @@ export default function Contact() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8 w-full max-w-6xl">
         {/* Left Section */}
         <motion.div
-          className="bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 dark:from-indigo-600 dark:via-purple-600 dark:to-pink-600 p-8 rounded-2xl shadow-2xl"
+          className="bg-white dark:bg-gray-900 p-8 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-800 transition-colors duration-300"
           initial={{ opacity: 0, x: -30 }}
           animate={{ opacity: 1, x: 0 }}
         >
-          <h2 className="text-2xl font-bold mb-4">Your Journey Starts Here</h2>
+          <h2 className="text-2xl font-bold mb-6 text-indigo-600 dark:text-indigo-400">Your Journey Starts Here</h2>
           <p className="mb-6 text-gray-800 dark:text-gray-100">
             Need help planning your next adventure? Whether it’s a family trip, solo
             backpacking, or business tour — we’ve got you covered.


### PR DESCRIPTION
Description
This pull request addresses a UI inconsistency on the Contact page where the two primary content cards ("Your Journey Starts Here" and "Get in Touch") had conflicting visual styles when a user is logged out or viewing in dark mode. The left card previously used a bright gradient background, while the right card used a solid dark background, creating a disjointed user experience.

This change unifies the design by applying the same solid background, border, and shadow styles to both cards, ensuring a cleaner, more professional, and visually consistent layout.



Changes Made
File Modified: src/pages/ContactUs.js
Removed the gradient background classes (bg-gradient-to-br, from-indigo-500, etc.) from the left-side "Your Journey Starts Here" card (motion.div).
Applied a solid background color (bg-white dark:bg-gray-900), a subtle border (border border-gray-200 dark:border-gray-800), and consistent shadows to match the right-side card.
Updated the heading color to better suit the new solid background (text-indigo-600 dark:text-indigo-400).



How to Test
Navigate to the Contact page of the application without being logged in.
Switch between light and dark mode.
Expected Result: Both cards on the page should now have the same solid background color and styling, appearing visually unified.



Visuals
Before:
The left card has a bright purple-to-pink gradient, clashing with the solid dark card on the right.
After:
Both cards now share the same modern, solid dark background, resulting in a clean and consistent UI.